### PR TITLE
ci: auto-publish on v* tag (Marketplace + Open VSX + GitHub Release)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,82 @@
+# Publish on `v*` tag push.
+#
+# What this does:
+#   1. Checks out the tagged commit.
+#   2. Verifies the tag matches package.json's version (catches "I pushed
+#      v2.0.1 but forgot to bump package.json" mistakes before they ship).
+#   3. Compiles TypeScript, packages a .vsix.
+#   4. Publishes to the VS Code Marketplace (vsce) using the VSCE_PAT secret.
+#   5. Publishes to Open VSX Registry (ovsx) using the OVSX_PAT secret.
+#   6. Attaches the .vsix to the GitHub Release for that tag, auto-generating
+#      release notes from PRs merged since the previous release.
+#
+# Usage:
+#   git tag v2.0.1 && git push origin v2.0.1
+#   ↳ this workflow then runs end to end. ~5 min wall-clock.
+#
+# Or trigger manually from Actions → Publish Extension → Run workflow
+# (workflow_dispatch — useful if a publish fails and we want to retry).
+
+name: Publish Extension
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write   # needed by softprops/action-gh-release to create / attach assets
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Belt-and-braces: refuse to publish if the tag doesn't match the
+      # version actually baked into package.json (which is what vsce reads).
+      - name: Verify tag matches package.json version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          VER=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$VER" ]; then
+            echo "::error::Tag v$TAG does not match package.json version $VER"
+            exit 1
+          fi
+          echo "OK: tag v$TAG matches package.json $VER"
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Package .vsix
+        run: npx -y @vscode/vsce package --out claude-code-usage.vsix
+
+      - name: Publish to VS Code Marketplace
+        run: npx -y @vscode/vsce publish --packagePath claude-code-usage.vsix --pat "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Publish to Open VSX Registry
+        run: npx -y ovsx publish claude-code-usage.vsix --pat "$OVSX_PAT"
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+
+      - name: Attach .vsix to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: claude-code-usage.vsix
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds .github/workflows/publish.yml. Triggers on `v*` tag push (and allows manual dispatch from the Actions tab for retries).

The workflow:
  - verifies the tag matches package.json's version (catches "forgot to bump" mistakes before they reach users)
  - compiles, packages the .vsix
  - publishes to the VS Code Marketplace via vsce, using the VSCE_PAT repo secret (already configured)
  - publishes to Open VSX via ovsx, using OVSX_PAT (already configured)
  - attaches the .vsix to the GitHub Release for the tag and auto- generates release notes from merged PRs (softprops/action-gh-release)

After this lands, future releases are:
  bump package.json version, update CHANGELOG, commit,
  git tag vX.Y.Z && git push origin vX.Y.Z