### PR TITLE
v2.0.2: Fable 5 pricing, attribution & quota fixes, cost-composition charts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Something isn't working as expected
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! A few details make bugs much faster to fix.
+        Tip: the `Claude Code Usage: Show Diagnostic Logs` command prints
+        per-refresh stats (files scanned, records kept/rejected, models seen)
+        that are very helpful for usage/pricing issues.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you see, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open the dashboard …
+        2. Click …
+        3. …
+  - type: input
+    id: ext-version
+    attributes:
+      label: Extension version
+      placeholder: e.g. 2.0.2
+    validations:
+      required: true
+  - type: input
+    id: cc-version
+    attributes:
+      label: Claude Code version
+      placeholder: e.g. 2.1.160
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other / Remote (SSH, devcontainer, WSL)
+  - type: input
+    id: proxy
+    attributes:
+      label: Proxy / model setup (if relevant)
+      description: e.g. CC Switch + DeepSeek, native Anthropic, LiteLLM proxy…
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostic logs (optional)
+      description: Output of `Claude Code Usage: Show Diagnostic Logs`, if applicable.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Heads-up on scope: this extension is intentionally
+        **Claude-only and lightweight**, focused on **token attribution** and
+        AI-assisted usage improvement. Multi-provider monitoring and full
+        billing reconciliation are out of scope. Ideas that sharpen token
+        insight or the advice experience are the best fit.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: The user need behind the request, not just the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,21 @@
+name: Question / Support
+description: Ask how something works or get help with setup
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Quick checks first: the [README](../../blob/main/README.md) covers
+        configuration, how costs are calculated, and troubleshooting (incl.
+        proxies, history retention, and the AI advice feature).
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context (optional)
+      description: Extension version, OS, proxy/model setup — whatever seems relevant.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for contributing! A consistently-structured PR makes review fast —
+and lets our (future) automated triage assist with first-pass analysis.
+Keep the section headings; fill what applies, delete what doesn't.
+-->
+
+## Summary
+
+<!-- What does this PR do, in 2–4 sentences? What problem does it solve? -->
+
+## Linked issues
+
+<!-- e.g. "Closes #42" / "Relates to #17". Write "None" if standalone. -->
+
+## Type of change
+
+<!-- Keep one: -->
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (existing behaviour differs afterwards)
+- [ ] Documentation / CI / chore
+
+## How was this tested?
+
+<!-- Manual steps in the Extension Development Host (F5), test runs, or
+     screenshots for UI changes. "Compiles" alone is not testing. -->
+
+## Checklist
+
+- [ ] `npm run compile` is clean
+- [ ] User-facing strings go through `I18n` with **all six languages** filled
+- [ ] `CHANGELOG.md` updated (user-visible changes)
+- [ ] `README.md` updated if behaviour/settings changed
+- [ ] New settings default to existing behaviour (opt-in)
+- [ ] No new runtime dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules
 .env.*
 *.env.local
 secrets.json
+
+# Personal, per-maintainer Claude Code notes (the shared CLAUDE.md is committed).
+CLAUDE.local.md

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,7 @@
       ],
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"
-      ],
-      "preLaunchTask": "npm: compile"
+      ]      "preLaunchTask": "npm: compile"
     }
   ]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,6 +7,7 @@ CLAUDE.md
 CLAUDE.local.md
 CONTRIBUTING.md
 probe-*.mjs
+docs/**
 
 .gitignore
 .yarnrc

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,8 @@
 .github/**
 src/**
 CLAUDE.md
+CLAUDE.local.md
+CONTRIBUTING.md
 probe-*.mjs
 
 .gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this fork compared to upstream
 [`jack21/ClaudeCodeUsage`](https://github.com/jack21/ClaudeCodeUsage) (last
 upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangelog.com).
 
+## [2.0.2] — 2026-06-09
+
+### Fixed
+- **Stale quota after reset** — the 5h / weekly indicator could keep showing
+  an old percentage (e.g. a lingering `5h:100%`) long after the window rolled
+  over. A window's utilisation is now dropped once its `resets_at` has passed;
+  if nothing current remains the indicator hides rather than asserting a stale
+  number. Adapted from [PR #24](https://github.com/jack21/ClaudeCodeUsage/pull/24)
+  by [@nickearnshaw](https://github.com/nickearnshaw).
+- **Slow status-bar updates during high-consumption runs** — refresh is now
+  activity-aware: while Claude Code is actively writing logs the poll ticks
+  every ~15 s and the quota cache shrinks to 20 s (so ultracode / workflow
+  runs update promptly); when idle it falls back to the user's interval.
+  Overlapping refresh triggers are coalesced instead of dropped, so rapid
+  sub-agent writes no longer starve updates.
+
+### Added
+- **Stacked cost-composition charts** on the This-Month (daily) and All-Time
+  (monthly) views, with a Y-axis and two reference lines. Each cost bar is
+  split into input / output / cache-write / cache-read, matching the summary's
+  Cost Composition colours — total spend and its breakdown at a glance. The
+  metric switcher still works (single bars for token / message metrics).
+
+### Docs
+- Fixed the `CHANGELOG.md` link casing in the README (was broken on
+  case-sensitive GitHub).
+- Refreshed all language READMEs to v2 (en / zh-TW / ja / ko concise; zh-CN
+  full translation).
+- Added `CONTRIBUTING.md` and GitHub issue templates.
+- Updated `CLAUDE.md` to the v2 architecture and release process.
+
+---
+
 ## [2.0.1] — 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,33 +6,64 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
 
 ## [2.0.2] — 2026-06-09
 
-### Fixed
-- **Stale quota after reset** — the 5h / weekly indicator could keep showing
-  an old percentage (e.g. a lingering `5h:100%`) long after the window rolled
-  over. A window's utilisation is now dropped once its `resets_at` has passed;
-  if nothing current remains the indicator hides rather than asserting a stale
-  number. Adapted from [PR #24](https://github.com/jack21/ClaudeCodeUsage/pull/24)
-  by [@nickearnshaw](https://github.com/nickearnshaw).
-- **Slow status-bar updates during high-consumption runs** — refresh is now
-  activity-aware: while Claude Code is actively writing logs the poll ticks
-  every ~15 s and the quota cache shrinks to 20 s (so ultracode / workflow
-  runs update promptly); when idle it falls back to the user's interval.
-  Overlapping refresh triggers are coalesced instead of dropped, so rapid
-  sub-agent writes no longer starve updates.
-
 ### Added
-- **Stacked cost-composition charts** on the This-Month (daily) and All-Time
-  (monthly) views, with a Y-axis and two reference lines. Each cost bar is
-  split into input / output / cache-write / cache-read, matching the summary's
-  Cost Composition colours — total spend and its breakdown at a glance. The
-  metric switcher still works (single bars for token / message metrics).
+- **Claude Fable 5 / Mythos 5** pricing ($10 / $50, cache write $12.50,
+  cache read $1 per MTok). Model ids with a `[1m]` long-context suffix are
+  now resolved to their base pricing (also fixes proxy configs like
+  `deepseek-v4-pro[1m]`).
+- **Stacked cost-composition charts** on the Today (hourly), This-Month
+  (daily) and All-Time (monthly) views, with a Y-axis and reference lines.
+  Each cost bar splits into input / output / cache-write / cache-read; the
+  metric switcher still renders single bars for token / message metrics.
+- **Sessions tab "Session" column** — the conversation title (the name
+  `claude --resume` shows), sortable, so same-project sessions are
+  distinguishable.
+- Dashboard **auto-refresh toggle** had already landed in 2.0.1; this release
+  refines its surrounding behaviour.
 
-### Docs
-- Fixed the `CHANGELOG.md` link casing in the README (was broken on
-  case-sensitive GitHub).
+### Fixed
+- **Quota indicator stale / stuck after reset** — an expired window now shows
+  0% (rolled forward to the new period) and is refetched, instead of lingering
+  on a stale value or vanishing. Adapted from
+  [PR #24](https://github.com/jack21/ClaudeCodeUsage/pull/24) by
+  [@nickearnshaw](https://github.com/nickearnshaw).
+- **Quota "only comes back after I restart VS Code"** — an expired in-memory
+  OAuth token now triggers a re-read of `~/.claude/.credentials.json` (which
+  Claude Code keeps refreshing) before our own refresh; the 429 cool-down was
+  cut from 5 minutes to 60 s; and the `/usage` fetch cadence was made gentler
+  (60 s active / 120 s idle) so rate-limiting is rare.
+- **Usage not showing the first time you open VS Code** — the status bar now
+  shows a loading state immediately and the quota fetch is non-blocking, so
+  local cost figures appear at once and the quota follows.
+  ([#26](https://github.com/jack21/ClaudeCodeUsage/issues/26))
+- **"This project" figure undercounted / disappeared** — per-conversation
+  attribution now keys off the session's home project directory instead of the
+  per-record working directory (which wanders mid-session), and the figure is
+  shown even at $0 instead of vanishing through the day.
+- **Message count** now counts messages you actually typed, excluding API
+  calls, command echoes (`/model` …) and interruption markers (a session that
+  read 106 now reads ~86). Token figures are unchanged.
+- **Per-metric chart Y-axis** now updates when switching metric (it was stuck
+  on the cost units).
+- **Activity-aware refresh** (≈8 s while Claude Code is writing, the user's
+  interval when idle) with coalesced triggers, so high-consumption ultracode /
+  Fable 5 runs update promptly without starving on rapid sub-agent writes.
+- **Sub-agent / workflow log attribution** — records under
+  `subagents/workflows/…` resolve to their parent session and real project
+  (were fragmenting into `wf_*` / `agent-*` pseudo-entries).
+- Drill-down charts: removed a double scrollbar; date labels parse the date
+  textually (UTC parsing shifted labels a day in negative-UTC timezones).
+- `launch.json` `preLaunchTask` fixed so F5 works in a single-root checkout
+  ([PR #22](https://github.com/jack21/ClaudeCodeUsage/pull/22), @nickearnshaw).
+
+### Docs / project
 - Refreshed all language READMEs to v2 (en / zh-TW / ja / ko concise; zh-CN
-  full translation).
-- Added `CONTRIBUTING.md` and GitHub issue templates.
+  full translation); fixed the `CHANGELOG.md` link casing.
+- Added `CONTRIBUTING.md`, a PR template, and issue templates; documented
+  `cleanupPeriodDays` for history retention
+  ([PR #21](https://github.com/jack21/ClaudeCodeUsage/pull/21), @nickearnshaw).
+- Loading-spinner / re-entrancy guard for the webview
+  ([PR #20](https://github.com/jack21/ClaudeCodeUsage/pull/20), @nickearnshaw).
 - Updated `CLAUDE.md` to the v2 architecture and release process.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,83 +1,80 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (and human contributors) working in this repository.
 
 ## Project Overview
 
-This is a VSCode extension called "Claude Code Usage" that monitors Claude Code usage and costs in the VSCode status bar. The extension reads Claude Code usage logs and displays real-time statistics including token consumption, costs, and message counts.
+"Claude Code Usage" is a VS Code extension that monitors Claude Code token
+usage and cost estimates in the status bar, with a detailed dashboard webview.
+It reads Claude Code's local `.jsonl` conversation logs and an OAuth-backed
+real `/usage` quota.
 
-## Architecture
+**Positioning (keep this in mind for every change):** Claude-only, lightweight,
+**token-precision over cost-precision**. Cost figures are estimates derived from
+public per-million-token rates — the product value is helping users *see where
+tokens go* and *use Claude Code better* (incl. the AI advice feature). Not a
+billing tool, not a multi-provider monitor.
 
-- **Main Entry Point**: `src/extension.ts` - Contains the main extension class and activation logic
-- **Data Processing**: `src/dataLoader.ts` - Handles loading and parsing Claude usage records from JSONL files
-- **UI Components**: 
-  - `src/statusBar.ts` - Manages the status bar display
-  - `src/webview.ts` - Provides detailed usage breakdown in a webview panel
-- **Internationalization**: `src/i18n.ts` - Multi-language support (English, 繁體中文, 简体中文, Japanese, Korean)
-- **Type Definitions**: `src/types.ts` - Core interfaces for usage data, session data, and configuration
+## Architecture (`src/`)
 
-## Development Commands
+- **`extension.ts`** — main class, activation, refresh orchestration. Owns the
+  adaptive refresh cadence (activity-aware: ~15 s while logs are being written,
+  the user's interval when idle), the re-entrancy guard + coalescing, the
+  `fs.watch` recursive file watcher, and the diagnostic `OutputChannel`.
+- **`dataLoader.ts`** — finds + parses `.jsonl` records; dedup (keeps the
+  higher-token record on a hash collision); aggregation (today / month / all
+  time / sessions / projects / branches); content analysis; diagnostic stats.
+- **`statusBar.ts`** — the two status-bar items (cost + quota). Quota tooltip is
+  an HTML progress bar; `liveWindows()` drops windows whose reset time has
+  passed so a stale value never lingers.
+- **`webview.ts`** — the dashboard (tabs, charts, tables). Large single file:
+  server-rendered HTML + an inlined client script. Cost charts render as
+  gridded stacked compositions.
+- **`pricing.ts`** — pricing table (Anthropic + reference rates for OpenAI /
+  Gemini / DeepSeek / Kimi / GLM / Qwen), family-aware fallback, LiteLLM
+  runtime refresh.
+- **`claudeApiClient.ts`** — OAuth credential read + token refresh + `/usage`
+  fetch. Routes through the system `curl` binary because Anthropic's edge
+  rejects Node's TLS fingerprint.
+- **`advisor.ts`** + **`adviceDemoSample.ts`** — the opt-in AI advice feature
+  and its localised static demo.
+- **`i18n.ts`** — translations for en / de-DE / zh-TW / zh-CN / ja / ko.
+- **`types.ts`** — shared interfaces.
+
+## Build & Release
+
+This repo is built with a **portable Node** (no global install assumed) and
+`@vscode/vsce`. Common commands:
 
 ```bash
-# Compile TypeScript to JavaScript
-npm run compile
-
-# Watch mode for development (automatically recompiles on changes)
-npm run watch
-
-# Prepare for publishing (runs compile)
-npm run vscode:prepublish
-
-# Package extension for distribution
-vsce package
-
-# Install extension locally for testing
-code --install-extension claude-code-usage-<version>.vsix
+npm run compile        # tsc -> out/
+npm run watch          # tsc --watch
+npx @vscode/vsce package   # build a .vsix
 ```
 
-## Testing and Debugging
+- **F5** launches the Extension Development Host for manual testing.
+- **Releases are automated.** Pushing a `v*` tag to the upstream repo triggers
+  `.github/workflows/publish.yml`, which compiles, packages, publishes to the
+  VS Code Marketplace + Open VSX, and attaches the `.vsix` to a GitHub Release.
+  The workflow verifies the tag matches `package.json`'s `version`. So to
+  release: bump `version`, update `CHANGELOG.md`, merge to `main`, then
+  `git tag vX.Y.Z && git push <upstream> vX.Y.Z`.
+- Versioning follows semver: bug-only → patch (`2.0.x`); new user-facing
+  feature → minor (`2.x.0`); breaking UX → major.
 
-- **F5 Key**: Launch Extension Development Host in VSCode to test the extension
-- **Extension Host**: The extension runs in a separate VSCode window for debugging
-- **Console Logs**: Use VSCode Developer Tools Console to view extension logs
+## Conventions
 
-## Key Technical Details
-
-- **Data Source**: Reads from Claude Code's JSONL usage logs located in `~/.config/claude/projects` or `~/.claude/projects`
-- **Caching Strategy**: Implements 1-minute cache to avoid excessive file I/O
-- **Auto-refresh**: Configurable refresh intervals (minimum 30 seconds)
-- **Token Types**: Tracks input, output, cache creation, and cache read tokens
-- **Cost Calculation**: Supports different model pricing with tier-based rates
-- **File Processing**: Native file search without external dependencies (removed tinyglobby and zod)
-- **Data Aggregation**: Processes JSONL files to calculate daily, weekly, monthly, and all-time usage statistics
-
-## Extension Configuration
-
-The extension contributes several VSCode settings under `claudeCodeUsage.*`:
-- `refreshInterval`: How often to update data (default: 60 seconds)
-- `dataDirectory`: Custom path to Claude data directory
-- `language`: Display language preference
-- `decimalPlaces`: Precision for cost display
-
-## Build Output
-
-Compiled JavaScript files are output to the `out/` directory, which serves as the extension's entry point via `package.json`'s `main` field.
-
-## Extension Commands
-
-The extension provides three commands accessible via Command Palette:
-- `Claude Code Usage: Refresh Usage Data` - Manually refresh the usage statistics
-- `Claude Code Usage: Show Usage Details` - Open detailed usage dashboard in webview
-- `Claude Code Usage: Open Settings` - Quick access to extension configuration
+- **Commit hygiene:** one meaningful commit per logical change; avoid a stream
+  of "fix the previous fix" commits. RC branches squash-merge to `main`.
+- **Tests:** pure-logic modules (pricing, aggregation, quota-window handling,
+  i18n) are the high-value test targets. A `node:test` suite is planned
+  (see issue #25).
+- **Data is read-only:** the extension never writes to `~/.claude/`.
 
 ## Documentation Maintenance
 
-**IMPORTANT**: When updating README.md, you MUST simultaneously update all language versions:
-- `README.md` (main, multi-language index)
-- `README-en.md` (English)
-- `README-zh-TW.md` (繁體中文)
-- `README-zh-CN.md` (简体中文)
-- `README-ja.md` (日本語)
-- `README-ko.md` (한국어)
-
-This ensures consistency across all documentation and maintains the multi-language support that users expect.
+When changing user-facing behaviour, update `README.md` (the canonical, fullest
+doc) and keep the language editions reasonably in sync:
+`README-en.md` (concise), `README-zh-CN.md` (full translation — highest-traffic
+locale), `README-zh-TW.md` / `README-ja.md` / `README-ko.md` (concise).
+`CHANGELOG.md` is the authoritative change record.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Thanks for your interest in Claude Code Usage — issues, PRs and ideas are
+genuinely welcome. This is a small, focused project and contributions are how
+it grows.
+
+## Project scope
+
+Before proposing a feature, it helps to know the positioning: this extension is
+intentionally **Claude-only and lightweight**, prioritising **token-precision**
+(seeing where tokens go) over cost-precision, and using AI to help people use
+Claude Code better. Multi-provider monitoring and full billing reconciliation
+are explicitly out of scope. Features that sharpen token attribution or the
+advice experience are the best fit.
+
+## Development setup
+
+```bash
+npm install
+npm run compile          # tsc -> out/
+npm run watch            # recompile on change
+```
+
+- Press **F5** in VS Code to launch the Extension Development Host and test
+  your changes manually.
+- Package a `.vsix` with `npx @vscode/vsce package`.
+
+The extension reads `~/.claude/projects/**/*.jsonl` **read-only** — it never
+writes to your Claude data.
+
+## Pull requests
+
+- Keep each PR focused on one logical change.
+- Run `npm run compile` and make sure it's clean before opening the PR.
+- Describe the problem and the fix; screenshots help for UI changes.
+- If your change affects user-facing behaviour, update `CHANGELOG.md` and the
+  relevant parts of `README.md`.
+
+## Tests
+
+There isn't a full test suite yet (tracked in
+[#25](https://github.com/jack21/ClaudeCodeUsage/issues/25)). The pure-logic
+modules — pricing (`pricing.ts`), aggregation (`dataLoader.ts`), quota-window
+handling (`statusBar.ts`), i18n formatting (`i18n.ts`) — are the high-value
+targets for `node:test`. If you add logic to these, lightweight tests are very
+welcome.
+
+## Releases
+
+Releases are automated: pushing a `v*` tag triggers the publish workflow
+(Marketplace + Open VSX + GitHub Release). Maintainers handle tagging.
+
+## Code of conduct
+
+Be kind and constructive. We're all here to make a useful tool.

--- a/README-en.md
+++ b/README-en.md
@@ -1,183 +1,79 @@
 # Claude Code Usage
 
-🌐 **Language | 語言 | 言語 | 언어**: [🏠 Main](README.md) | **English** | [繁體中文](README-zh-TW.md) | [简体中文](README-zh-CN.md) | [日本語](README-ja.md) | [한국어](README-ko.md)
+🌐 **Language**: [🏠 Main](README.md) | **English** | [繁體中文](README-zh-TW.md) | [简体中文](README-zh-CN.md) | [日本語](README-ja.md) | [한국어](README-ko.md)
 
 ---
 
-The Claude Code coach in your status bar. Not a billing tool. Not a multi-provider monitor. A focused token tracker that uses AI to help you use Claude Code better.
+**The Claude Code coach in your status bar.** Not a billing tool. Not a multi-provider monitor. A focused token tracker that uses AI to help you use Claude Code better.
 
-## 🖼️ Screenshot
+> **What it is:** a VS Code status-bar monitor that reads your local Claude Code conversation logs and shows **token-derived** usage and cost estimates — plus an optional AI advisor that suggests how to improve your prompts and reduce waste.
+>
+> **What it is _not_:** a billing tool. All amounts are estimates based on public per-million-token rates. Refer to your Anthropic account for actual charges.
 
-### Status Bar
+> Screenshots are from the English UI. See the [main README](README.md) for the full feature reference.
 
-![Status Bar Preview](https://raw.githubusercontent.com/jack21/ClaudeCodeUsage/refs/heads/main/images/status-bar-preview.jpg)
+## Screenshots
+
+### Status bar
+
+![Status bar](images/v2-status-bar-en.png)
+
+Hover the quota indicator for a breakdown:
+
+![Quota tooltip](images/v2-quota-en.png)
 
 ### Dashboard
 
-![Dashboard Preview](https://raw.githubusercontent.com/jack21/ClaudeCodeUsage/refs/heads/main/images/dashboard-preview.jpg)
+![Dashboard](images/v2-dashboard-en.png)
 
-## ✨ Features
+## Features
 
-### 📊 Real-time Monitoring
+- **Status bar** — today's cost, current-session cost, and real 5-hour / weekly quota (`5h:N% wk:N%`) read from Claude Code's own OAuth session. Zero configuration.
+- **Dashboard tabs** — Today / This Month / All Time, plus **Sessions / Projects / Content / Branches**, all sortable.
+- **Stacked cost-composition charts** with a Y-axis and reference lines — see at a glance how much of each day / month went to input, output, cache-write and cache-read.
+- **Content tab** — estimates which content consumes your tokens (your prompts vs. tool results vs. assistant output / thinking).
+- **AI advice** (opt-in) — sends a usage summary plus a sample of your prompts to an OpenAI-compatible API (DeepSeek V4 Pro by default) and suggests concrete rewrites. Bring your own key, or preview a static demo first.
+- **Multi-vendor pricing** — Opus 4.x / Sonnet 4.x / Haiku 4.5 verified against Anthropic's public pricing; reference rates for OpenAI / Gemini / DeepSeek / Kimi / GLM / Qwen with family-aware fallback. `Refresh Token Pricing` pulls live LiteLLM data.
+- **Personalisation** — language, timezone, decimal places, compact numbers, project grouping, dashboard auto-refresh toggle.
 
-- **Status Bar Display**: Shows today's usage costs in the VSCode status bar
-- **Live Updates**: Automatic data refresh with configurable intervals (minimum 30 seconds)
-- **Zero Dependencies**: Built with native Node.js modules for maximum compatibility
+## Install
 
-### 📈 Interactive Analytics Dashboard
+Search for **`Claude Code Usage`** in the Extensions view (`Ctrl+Shift+X`), or:
 
-- **Multiple Time Views**: Today, This Month, and All Time perspectives
-- **Interactive Charts**: Switchable bar charts with 6 different metrics:
-  - Cost breakdown
-  - Input/Output tokens
-  - Cache creation/read tokens
-  - Message counts
-- **Hourly Breakdown**: Detailed hourly usage analysis for today and specific dates
-- **Expandable Monthly Data**: Click on any month in "All Time" to view daily breakdown
-- **Detailed Tables**: Comprehensive daily/monthly usage breakdowns with drill-down capabilities
-- **Model Analysis**: Per-model cost and token consumption tracking
+```
+ext install GrowthJack.claude-code-usage
+```
 
-![Dashboard Preview](images/dashboard-preview.png)
-
-### 🌐 Multi-language Support
-
-- **5 Languages**: English, 繁體中文, 简体中文, 日本語, 한국어
-- **Auto-detection**: Automatically detects system language
-- **Manual Override**: Choose your preferred language in settings
-
-### 🎨 Visual Features
-
-- **Bottom-up Charts**: Industry-standard chart orientation
-- **Monthly Trends**: All-time view shows monthly aggregated data for long-term analysis
-- **VSCode Theme Integration**: Seamless light/dark theme support
-- **Responsive Design**: Optimized for different screen sizes
-
-## 📥 Download
-
-### VSCode Marketplace
-
-[![VSCode Marketplace](https://img.shields.io/visual-studio-marketplace/v/growthjack.claude-code-usage?style=for-the-badge&logo=visual-studio-code&label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=growthjack.claude-code-usage)
-
-### Open VSX Registry (for Cursor / Windsurf / Antigravity)
-
-[![Open VSX](https://img.shields.io/open-vsx/v/GrowthJack/claude-code-usage?style=for-the-badge&logo=eclipseide&label=Open%20VSX%20Registry)](https://marketplace.cursorapi.com/items/?itemName=GrowthJack.claude-code-usage)
-
-## Installation
-
-1. Install the extension from the VSCode marketplace
-2. The extension will automatically detect your Claude Code data directory
-3. Start using Claude Code and see your usage appear in the status bar
+Also on the [Open VSX Registry](https://open-vsx.org/extension/GrowthJack/claude-code-usage) for Cursor / Windsurf.
 
 ## Configuration
 
-Access settings via `File > Preferences > Settings` and search for "Claude Code Usage":
+Open Settings (`Ctrl+,`) and search for **`Claude Code Usage`**. All settings are optional. The most useful:
 
-- **Refresh Interval**: How often to update usage data (minimum 30 seconds)
-- **Data Directory**: Custom Claude data directory path (leave empty for auto-detection)
-- **Language**: Display language preference
-- **Decimal Places**: Number of decimal places for cost display
+- `language` — UI language (`auto` / `en` / `zh-TW` / `zh-CN` / `ja` / `ko`).
+- `timezone` — IANA timezone for date display (e.g. `Asia/Hong_Kong`).
+- `usageLimitTracking` — show the real 5h / weekly quota indicator.
+- `advice.apiKey` — API key for the AI advice feature (OpenAI-compatible).
+- `pauseDashboardRefresh` — pause dashboard auto-refresh (also toggleable in the dashboard header).
 
-## 🚀 Usage
+See the [full settings table in the main README](README.md#configuration).
 
-### Status Bar
+## Troubleshooting
 
-- Shows **today's usage cost** with a pulse icon
-- Click to open the detailed analytics dashboard
+**"No Claude Code Data"** — make sure Claude Code is installed and used at least once; check the `dataDirectory` setting (auto-detection looks at `~/.claude/projects`).
 
-### Analytics Dashboard
+**Quota shows `5h:--% wk:--%`** — log in to Claude Code once; the extension reads `~/.claude/.credentials.json` read-only.
 
-1. **Time Tabs**: Switch between Today, This Month, and All Time views
-2. **Chart Metrics**: Click tabs above charts to switch between:
-   - Cost breakdown
-   - Input/Output tokens
-   - Cache creation/read tokens
-   - Message counts
-3. **Hourly Analysis**: View hourly usage patterns in "Today" tab
-4. **Expandable Data**:
-   - Click on daily entries in "This Month" to see hourly breakdown
-   - Click on monthly entries in "All Time" to see daily breakdown
-5. **Interactive Tables**: Detailed daily/monthly breakdowns below charts
-6. **Model Analysis**: Per-model usage statistics in each tab
+**Usage history is missing older months** — Claude Code deletes logs older than `cleanupPeriodDays` (default 30). To keep more, set `{ "cleanupPeriodDays": 365 }` in `~/.claude/settings.json`. Already-deleted logs can't be recovered.
 
-## 📋 Requirements
+**Token counts lower than your provider's dashboard** — some proxies / dynamic workflows write per-agent records to sub-directories that may be incomplete. Your actual spend is on your provider's billing page. Native workflow attribution is planned.
 
-- **Claude Code**: Must be installed and running
-- **VSCode**: Version 1.74.0 or later
-- **Node.js**: Built-in modules only (no external dependencies)
+## Credits
 
-## 🛠️ Troubleshooting
+Forked from [`jack21/ClaudeCodeUsage`](https://github.com/jack21/ClaudeCodeUsage). MIT-licensed. Community contributions credited in [CHANGELOG.md](CHANGELOG.md). Many code changes drafted with [Claude Code](https://claude.com/claude-code).
 
-### "No Claude Code Data" Error
-
-1. Ensure Claude Code is installed and has been used
-2. Check the data directory setting in extension preferences
-3. Verify Claude Code is generating usage logs in `~/.claude/projects` or `~/.config/claude/projects`
-
-### Charts Not Updating
-
-1. Switch to a different tab and back to refresh the chart
-2. Check if the time period has actual usage data
-3. Verify cache tokens are available in your Claude usage
-
-### Performance Issues
-
-- Increase refresh interval if experiencing slowdowns
-- Extension uses 1-minute caching to minimize file I/O
+**Issues, PRs and ideas are warmly welcomed** — that's how the project grows.
 
 ## License
 
-MIT
-
-## 📝 Changelog
-
-### v1.0.8 (2025-11-28)
-
-- 📝 Converted all code comments from Traditional Chinese to English
-- 🌍 Improved code internationalization standards
-- 🔧 Enhanced code readability and maintainability
-- 💰 Fixed pricing table with new Opus 4.5 / Haiku 4.5 prices (thanks to [@mxzinke](https://github.com/mxzinke))
-- 🇩🇪 Added German (de-DE) translation support (thanks to [@mxzinke](https://github.com/mxzinke))
-
-### v1.0.7 (2025-11-28)
-
-- 🌐 Added multilingual translation support for hourly usage labels
-- 🔧 Removed hardcoded Chinese text from code, replaced with i18n translation system
-- ✨ Ensured multilingual consistency across user interface (English, Traditional Chinese, Simplified Chinese, Japanese, Korean)
-
-### v1.0.6 (2025-08-10)
-
-- 🆕 Added support for Claude Opus 4.1 model pricing
-- 🔄 Updated pricing data to include `claude-opus-4-1-20250805` and `claude-opus-4-1` model IDs
-- 📊 Pricing remains the same as Opus 4 ($15/1M input, $75/1M output tokens)
-
-### v1.0.5 (2025-01)
-
-- ⏰ Added hourly usage statistics and visualization
-- 📈 Enhanced dashboard with hourly breakdown functionality
-- 🔧 Improved data processing for hourly aggregation
-
-### v1.0.4 (2025-01)
-
-- 📊 Added all-time data calculation functionality
-- 🎨 Updated UI to display all-time usage data with charts and labels
-- 🔄 Fixed data update logic to support new data structure
-- 🌐 Added "All Time" translations to multi-language support
-
-### v1.0.3 (2025-01)
-
-- 🔗 Updated GitHub repository URL
-- 🖼️ Fixed README image links to point to new repository location
-- 📦 Version bump and repository migration
-
-### v1.0.0 (2025-01)
-
-- 🎉 Initial complete release
-- 📊 Real-time Claude Code usage monitoring in status bar
-- 🌐 Multi-language support (English, 繁體中文, 简体中文, 日本語, 한국어)
-- 📈 Interactive analytics dashboard with charts and tables
-- 🎨 VSCode theme integration and responsive design
-- ⚙️ Configurable refresh intervals and settings
-
-## Contributing
-
-Issues and pull requests are welcome on the GitHub repository.
+[MIT](LICENSE)

--- a/README-ja.md
+++ b/README-ja.md
@@ -1,185 +1,79 @@
 # Claude Code 使用量モニター
 
-🌐 **Language | 語言 | 言語 | 언어**: [🏠 Main](README.md) | [English](README-en.md) | [繁體中文](README-zh-TW.md) | [简体中文](README-zh-CN.md) | **日本語** | [한국어](README-ko.md)
+🌐 **言語**: [🏠 Main](README.md) | [English](README-en.md) | [繁體中文](README-zh-TW.md) | [简体中文](README-zh-CN.md) | **日本語** | [한국어](README-ko.md)
 
 ---
 
-Claude Code をより賢く使うための、ステータスバーコーチ。請求ツールでも、マルチプロバイダー監視でもありません。AI を活用してトークン消費を分析し、使い方を改善する軽量 VS Code 拡張機能です。
+**Claude Code をより賢く使うための、ステータスバーコーチ。** 請求ツールでも、マルチプロバイダー監視でもありません。AI を活用してトークン消費を分析し、使い方を改善する軽量 VS Code 拡張機能です。
 
-## 🖼️ スクリーンショット
+> **これは何か**：ローカルの Claude Code 会話ログを読み取り、**トークンから算出した**使用量とコストの見積もりを表示する VS Code ステータスバーモニター。さらに、プロンプトの改善と無駄削減を提案する任意の AI アドバイザー付き。
+>
+> **これは何ではないか**：請求ツールではありません。表示される金額はすべて公開のトークン単価に基づく見積もりです。実際の請求は Anthropic アカウントをご確認ください。
+
+> スクリーンショットは英語 UI のものです。全機能の詳細は[メイン README](README.md) を参照してください。
+
+## スクリーンショット
 
 ### ステータスバー
 
-![ステータスバープレビュー](https://raw.githubusercontent.com/jack21/ClaudeCodeUsage/refs/heads/main/images/status-bar-preview.jpg)
+![ステータスバー](images/v2-status-bar-en.png)
+
+クォータ表示にカーソルを合わせると内訳が出ます：
+
+![クォータツールチップ](images/v2-quota-en.png)
 
 ### ダッシュボード
 
-![ダッシュボードプレビュー](https://raw.githubusercontent.com/jack21/ClaudeCodeUsage/refs/heads/main/images/dashboard-preview.jpg)
+![ダッシュボード](images/v2-dashboard-en.png)
 
-## ✨ 機能
+## 主な機能
 
-### 📊 リアルタイム監視
-
-- **ステータスバー表示**：VSCode ステータスバーに今日の使用コストを表示
-- **ライブ更新**：設定可能な間隔（最小 30 秒）での自動データ更新
-- **依存関係ゼロ**：ネイティブ Node.js モジュールを使用し、最大の互換性を実現
-
-### 📈 インタラクティブ分析ダッシュボード
-
-- **複数の時間ビュー**：今日、今月、すべての時間の視点
-- **インタラクティブチャート**：6 つの異なる指標を切り替え可能な棒グラフ：
-  - コスト分析
-  - 入力/出力トークン
-  - キャッシュ作成/読み取りトークン
-  - メッセージ数
-- **時間別分析**：今日および特定の日付の詳細な時間別使用量分析
-- **展開可能な月次データ**：「すべての時間」で任意の月をクリックして日別内訳を表示
-- **詳細テーブル**：ドリルダウン機能付きの包括的な日次/月次使用量の内訳
-- **モデル分析**：モデル別のコストとトークン消費の追跡
-
-![ダッシュボードプレビュー](images/dashboard-preview.png)
-
-### 🌐 多言語サポート
-
-- **5 言語**：English, 繁體中文, 简体中文, 日本語, 한국어
-- **自動検出**：システム言語を自動検出
-- **手動オーバーライド**：設定で好みの言語を選択
-
-### 🎨 視覚機能
-
-- **ボトムアップチャート**：業界標準のチャート方向
-- **月次トレンド**：すべての時間ビューで月次集計データを表示し、長期トレンド分析に対応
-- **VSCode テーマ統合**：ライト/ダークテーマとのシームレスな統合
-- **レスポンシブデザイン**：異なる画面サイズに最適化
-
-## 📥 ダウンロード
-
-### VSCode Marketplace
-
-[![VSCode Marketplace](https://img.shields.io/visual-studio-marketplace/v/growthjack.claude-code-usage?style=for-the-badge&logo=visual-studio-code&label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=growthjack.claude-code-usage)
-
-### Open VSX Registry（Cursor / Windsurf / Antigravity 用）
-
-[![Open VSX](https://img.shields.io/open-vsx/v/GrowthJack/claude-code-usage?style=for-the-badge&logo=eclipseide&label=Open%20VSX%20Registry)](https://marketplace.cursorapi.com/items/?itemName=GrowthJack.claude-code-usage)
+- **ステータスバー** — 本日のコスト、現在のセッションのコスト、そして Claude Code 自身の OAuth セッションから読み取る実際の 5 時間 / 週間クォータ（`5h:N% wk:N%`）。設定不要。
+- **ダッシュボードタブ** — 今日 / 今月 / 全期間 に加え、**Sessions / Projects / Content / Branches**。すべて並べ替え可能。
+- **積み上げコスト構成チャート**（Y 軸と参照線付き）— 各日 / 各月のコストが入力・出力・キャッシュ書き込み・キャッシュ読み取りにどれだけ使われたか一目で分かります。
+- **Content タブ** — どの内容がトークンを消費しているか（あなたのプロンプト vs ツール結果 vs アシスタント出力 / 思考）を推定。
+- **AI アドバイス**（任意）— 使用量サマリーと最近のプロンプトのサンプルを OpenAI 互換 API（デフォルト DeepSeek V4 Pro）に送り、具体的な書き換えを提案。キーは自分で用意、または静的デモを先にプレビュー可能。
+- **マルチベンダー価格** — Opus 4.x / Sonnet 4.x / Haiku 4.5 は Anthropic 公式価格で検証済み。OpenAI / Gemini / DeepSeek / Kimi / GLM / Qwen の参考価格（ファミリー認識フォールバック付き）。`Refresh Token Pricing` で LiteLLM の最新価格を取得。
+- **パーソナライズ** — 言語、タイムゾーン、小数点桁数、コンパクト数値、プロジェクトのグループ化、ダッシュボード自動更新の切り替え。
 
 ## インストール
 
-1. VSCode マーケットプレイスから拡張機能をインストール
-2. 拡張機能が Claude Code データディレクトリを自動検出
-3. Claude Code の使用を開始すると、使用量がステータスバーに表示されます
+拡張機能ビュー（`Ctrl+Shift+X`）で **`Claude Code Usage`** を検索するか：
+
+```
+ext install GrowthJack.claude-code-usage
+```
+
+Cursor / Windsurf 向けに [Open VSX Registry](https://open-vsx.org/extension/GrowthJack/claude-code-usage) でも公開しています。
 
 ## 設定
 
-`ファイル > 基本設定 > 設定` から「Claude Code Usage」を検索してアクセス：
+設定（`Ctrl+,`）を開き **`Claude Code Usage`** を検索。すべて任意です。よく使うもの：
 
-- **更新間隔**：使用データを更新する頻度（最小 30 秒）
-- **データディレクトリ**：カスタム Claude データディレクトリパス（空欄で自動検出）
-- **言語**：表示言語の設定
-- **小数点以下の桁数**：コスト表示の小数点以下桁数
+- `language` — UI 言語（`auto` / `en` / `zh-TW` / `zh-CN` / `ja` / `ko`）。
+- `timezone` — 日付表示用の IANA タイムゾーン（例 `Asia/Tokyo`）。
+- `usageLimitTracking` — 実際の 5 時間 / 週間クォータ表示。
+- `advice.apiKey` — AI アドバイス機能の API キー（OpenAI 互換）。
+- `pauseDashboardRefresh` — ダッシュボードの自動更新を一時停止（ダッシュボードのヘッダーでも切り替え可能）。
 
-## 🚀 使用方法
+設定の全一覧は[メイン README](README.md#configuration) を参照。
 
-### ステータスバー
+## トラブルシューティング
 
-- パルスアイコン付きで**今日の使用コスト**を表示
-- クリックして詳細な分析ダッシュボードを開く
+**「No Claude Code Data」** — Claude Code がインストールされ、少なくとも一度使用されていることを確認。`dataDirectory` 設定を確認（自動検出は `~/.claude/projects` を参照）。
 
-### 分析ダッシュボード
+**クォータが `5h:--% wk:--%`** — Claude Code に一度ログインしてください。拡張機能は `~/.claude/.credentials.json` を読み取り専用で参照します。
 
-1. **時間タブ**：今日、今月、すべての時間ビュー間を切り替え
-2. **チャート指標**：チャート上のタブをクリックして異なる指標を切り替え：
-   - コスト分析
-   - 入力/出力トークン
-   - キャッシュ作成/読み取りトークン
-   - メッセージ数
-3. **時間別分析**：「今日」タブで時間別の使用パターンを表示
-4. **展開可能データ**：
-   - 「今月」の日別エントリをクリックして時間別内訳を表示
-   - 「すべての時間」の月別エントリをクリックして日別内訳を表示
-5. **インタラクティブテーブル**：チャート下の詳細な日別/月別内訳
-6. **モデル分析**：各タブのモデル別使用統計
+**古い月の履歴がない** — Claude Code は `cleanupPeriodDays`（デフォルト 30 日）より古いログを削除します。保持期間を延ばすには `~/.claude/settings.json` に `{ "cleanupPeriodDays": 365 }` を設定。削除済みのログは復元できません。
 
-![使用フロー](images/usage-flow.png)
+**トークン数がプロバイダーのダッシュボードより少ない** — 一部のプロキシ / 動的ワークフローはエージェントごとの記録をサブディレクトリに書き込み、不完全な場合があります。実際の消費はプロバイダーの請求ページをご確認ください。ネイティブのワークフロー帰属は計画中です。
 
-## 📋 要件
+## クレジット
 
-- **Claude Code**：インストールされ、実行されている必要があります
-- **VSCode**：バージョン 1.74.0 以降
-- **Node.js**：組み込みモジュールのみ（外部依存関係なし）
+[`jack21/ClaudeCodeUsage`](https://github.com/jack21/ClaudeCodeUsage) からフォーク。MIT ライセンス。コミュニティの貢献は [CHANGELOG.md](CHANGELOG.md) に記載。多くのコード変更は [Claude Code](https://claude.com/claude-code) の支援で作成されました。
 
-## 🛠️ トラブルシューティング
-
-### 「Claude Code データなし」エラー
-
-1. Claude Code がインストールされ、使用されていることを確認
-2. 拡張機能設定でデータディレクトリ設定を確認
-3. Claude Code が `~/.claude/projects` または `~/.config/claude/projects` で使用ログを生成していることを確認
-
-### チャートが更新されない
-
-1. 別のタブに切り替えてから戻ってチャートを更新
-2. その時期に実際の使用データがあるか確認
-3. Claude 使用記録にキャッシュトークンがあるか確認
-
-### パフォーマンスの問題
-
-- 速度低下が発生した場合は更新間隔を増やしてください
-- 拡張機能はファイル I/O を最小限に抑えるため 1 分間のキャッシュを使用しています
-
-## 📝 更新履歴
-
-### v1.0.8 (2025-11-28)
-
-- 📝 すべてのコードコメントを繁体字中国語から英語に変換
-- 🌍 コードの国際化標準を向上
-- 🔧 コードの可読性と保守性を強化
-- 💰 新しい Opus 4.5 / Haiku 4.5 価格を含む価格表を修正（[@mxzinke](https://github.com/mxzinke) に感謝）
-- 🇩🇪 ドイツ語（de-DE）翻訳サポートを追加（[@mxzinke](https://github.com/mxzinke) に感謝）
-
-### v1.0.7 (2025-11-28)
-
-- 🌐 時間別使用量ラベルの多言語翻訳サポートを追加
-- 🔧 コード内のハードコードされた中国語テキストを削除し、i18n 翻訳システムに置き換え
-- ✨ ユーザーインターフェースの多言語一貫性を確保（英語、繁体字中国語、簡体字中国語、日本語、韓国語）
-
-### v1.0.6 (2025-08-10)
-
-- 🆕 Claude Opus 4.1 モデルの価格設定サポートを追加
-- 🔄 `claude-opus-4-1-20250805` と `claude-opus-4-1` モデル ID を含む価格データを更新
-- 📊 価格は Opus 4 と同じ（入力$15/1M トークン、出力$75/1M トークン）
-
-### v1.0.5 (2025-01)
-
-- ⏰ 時間別使用量統計と可視化を追加
-- 📈 時間別詳細機能でダッシュボードを強化
-- 🔧 時間別集計のデータ処理を改善
-
-### v1.0.4 (2025-01)
-
-- 📊 全期間データ計算機能を追加
-- 🎨 全期間使用データをチャートとラベルで表示する UI を更新
-- 🔄 新しいデータ構造をサポートするためのデータ更新ロジックを修正
-- 🌐 多言語サポートに「全期間」の翻訳を追加
-
-### v1.0.3 (2025-01)
-
-- 🔗 GitHub リポジトリ URL を更新
-- 🖼️ README の画像リンクを新しいリポジトリ位置に修正
-- 📦 バージョンアップとリポジトリ移行
-
-### v1.0.0 (2025-01)
-
-- 🎉 初回完全リリース版
-- 📊 ステータスバーでのリアルタイム Claude Code 使用量監視
-- 🌐 多言語サポート（English, 繁體中文, 简体中文, 日本語, 한국어）
-- 📈 チャートとテーブルを含むインタラクティブな分析ダッシュボード
-- 🎨 VSCode テーマ統合とレスポンシブデザイン
-- ⚙️ 設定可能な更新間隔と設定
+**Issue・PR・アイデアを歓迎します** —— それがプロジェクトの成長につながります。
 
 ## ライセンス
 
-MIT
-
-## 貢献
-
-GitHub リポジトリで Issue や Pull Request を歓迎します。
+[MIT](LICENSE)

--- a/README-ko.md
+++ b/README-ko.md
@@ -1,185 +1,79 @@
 # Claude Code 사용량 모니터
 
-🌐 **Language | 語言 | 言語 | 언어**: [🏠 Main](README.md) | [English](README-en.md) | [繁體中文](README-zh-TW.md) | [简体中文](README-zh-CN.md) | [日本語](README-ja.md) | **한국어**
+🌐 **언어**: [🏠 Main](README.md) | [English](README-en.md) | [繁體中文](README-zh-TW.md) | [简体中文](README-zh-CN.md) | [日本語](README-ja.md) | **한국어**
 
 ---
 
-Claude Code를 더 스마트하게 쓰는 방법을 알려주는 상태 표시줄 코치. 청구 도구도, 멀티 프로바이더 모니터도 아닙니다. AI를 활용해 토큰 소비를 분석하고 사용 습관을 개선하는 가벼운 VS Code 확장입니다.
+**Claude Code를 더 스마트하게 쓰는 방법을 알려주는 상태 표시줄 코치.** 청구 도구도, 멀티 프로바이더 모니터도 아닙니다. AI를 활용해 토큰 소비를 분석하고 사용 습관을 개선하는 가벼운 VS Code 확장입니다.
 
-## 🖼️ 스크린샷
+> **무엇인가**: 로컬 Claude Code 대화 로그를 읽어 **토큰 기반**의 사용량과 비용 추정치를 보여주는 VS Code 상태 표시줄 모니터. 프롬프트 개선과 낭비 절감을 제안하는 선택적 AI 어드바이저 포함.
+>
+> **무엇이 아닌가**: 청구 도구가 아닙니다. 표시되는 모든 금액은 공개된 100만 토큰당 단가 기준 추정치입니다. 실제 청구는 Anthropic 계정을 확인하세요.
 
-### 상태바
+> 스크린샷은 영어 UI 기준입니다. 전체 기능 설명은 [메인 README](README.md)를 참고하세요.
 
-![상태바 미리보기](https://raw.githubusercontent.com/jack21/ClaudeCodeUsage/refs/heads/main/images/status-bar-preview.jpg)
+## 스크린샷
+
+### 상태 표시줄
+
+![상태 표시줄](images/v2-status-bar-en.png)
+
+쿼터 표시기에 마우스를 올리면 상세 내역이 나옵니다:
+
+![쿼터 툴팁](images/v2-quota-en.png)
 
 ### 대시보드
 
-![대시보드 미리보기](https://raw.githubusercontent.com/jack21/ClaudeCodeUsage/refs/heads/main/images/dashboard-preview.jpg)
+![대시보드](images/v2-dashboard-en.png)
 
-## ✨ 기능
+## 기능
 
-### 📊 실시간 모니터링
-
-- **상태바 표시**: VSCode 상태바에 오늘의 사용 비용 표시
-- **실시간 업데이트**: 설정 가능한 간격(최소 30초)으로 자동 데이터 업데이트
-- **의존성 제로**: 네이티브 Node.js 모듈 사용으로 최대 호환성 보장
-
-### 📈 인터랙티브 분석 대시보드
-
-- **다중 시간 뷰**: 오늘, 이번 달, 전체 기간의 관점
-- **인터랙티브 차트**: 6가지 다른 지표로 전환 가능한 막대 차트:
-  - 비용 분석
-  - 입력/출력 토큰
-  - 캐시 생성/읽기 토큰
-  - 메시지 수
-- **시간별 사용량 분석**: 오늘과 특정 날짜의 상세한 시간별 사용량 분석 제공
-- **확장 가능한 월별 데이터**: "전체 기간"에서 임의의 월을 클릭하여 일별 세부사항 보기
-- **상세 테이블**: 드릴다운 기능이 있는 포괄적인 일일/월별 사용량 분석
-- **모델 분석**: 모델별 비용 및 토큰 소비 추적
-
-![대시보드 미리보기](images/dashboard-preview.png)
-
-### 🌐 다국어 지원
-
-- **5개 언어**: English, 繁體中文, 简体中文, 日本語, 한국어
-- **자동 감지**: 시스템 언어 자동 감지
-- **수동 설정**: 설정에서 선호 언어 선택
-
-### 🎨 시각적 기능
-
-- **상향식 차트**: 업계 표준 차트 방향
-- **월별 트렌드**: 전체 기간 뷰에서 월별 집계 데이터 표시로 장기 트렌드 분석 지원
-- **VSCode 테마 통합**: 라이트/다크 테마와의 완벽한 통합
-- **반응형 디자인**: 다양한 화면 크기에 최적화
-
-## 📥 다운로드
-
-### VSCode Marketplace
-
-[![VSCode Marketplace](https://img.shields.io/visual-studio-marketplace/v/growthjack.claude-code-usage?style=for-the-badge&logo=visual-studio-code&label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=growthjack.claude-code-usage)
-
-### Open VSX Registry（Cursor / Windsurf / Antigravity용）
-
-[![Open VSX](https://img.shields.io/open-vsx/v/GrowthJack/claude-code-usage?style=for-the-badge&logo=eclipseide&label=Open%20VSX%20Registry)](https://marketplace.cursorapi.com/items/?itemName=GrowthJack.claude-code-usage)
+- **상태 표시줄** — 오늘 비용, 현재 세션 비용, 그리고 Claude Code 자체 OAuth 세션에서 읽는 실제 5시간 / 주간 쿼터(`5h:N% wk:N%`). 설정 불필요.
+- **대시보드 탭** — 오늘 / 이번 달 / 전체 기간, 그리고 **Sessions / Projects / Content / Branches**. 모두 정렬 가능.
+- **누적 비용 구성 차트**(Y축과 기준선 포함) — 각 일 / 월의 비용 중 입력·출력·캐시 쓰기·캐시 읽기가 차지하는 비율을 한눈에.
+- **Content 탭** — 어떤 콘텐츠가 토큰을 소비하는지 추정(내 프롬프트 vs 도구 결과 vs 어시스턴트 출력 / 사고).
+- **AI 조언**(선택) — 사용량 요약과 최근 프롬프트 샘플을 OpenAI 호환 API(기본 DeepSeek V4 Pro)로 보내 구체적인 재작성을 제안. 키는 직접 준비하거나, 정적 데모를 먼저 미리보기.
+- **멀티 벤더 가격** — Opus 4.x / Sonnet 4.x / Haiku 4.5는 Anthropic 공식 가격으로 검증. OpenAI / Gemini / DeepSeek / Kimi / GLM / Qwen 참고 가격(패밀리 인식 폴백 포함). `Refresh Token Pricing`으로 LiteLLM 최신 가격 가져오기.
+- **개인화** — 언어, 시간대, 소수 자릿수, 간략 숫자, 프로젝트 그룹화, 대시보드 자동 새로고침 토글.
 
 ## 설치
 
-1. VSCode 마켓플레이스에서 확장 프로그램 설치
-2. 확장 프로그램이 Claude Code 데이터 디렉토리를 자동 감지
-3. Claude Code 사용을 시작하면 상태 표시줄에 사용량이 나타납니다
+확장 보기(`Ctrl+Shift+X`)에서 **`Claude Code Usage`**를 검색하거나:
+
+```
+ext install GrowthJack.claude-code-usage
+```
+
+Cursor / Windsurf용으로 [Open VSX Registry](https://open-vsx.org/extension/GrowthJack/claude-code-usage)에도 게시되어 있습니다.
 
 ## 설정
 
-`파일 > 기본 설정 > 설정`에서 "Claude Code Usage"를 검색하여 접근:
+설정(`Ctrl+,`)을 열고 **`Claude Code Usage`**를 검색하세요. 모두 선택 사항입니다. 가장 유용한 것:
 
-- **새로고침 간격**: 사용 데이터를 업데이트하는 빈도 (최소 30초)
-- **데이터 디렉토리**: 커스텀 Claude 데이터 디렉토리 경로 (비워두면 자동 감지)
-- **언어**: 표시 언어 설정
-- **소수점 자릿수**: 비용 표시의 소수점 자릿수
+- `language` — UI 언어(`auto` / `en` / `zh-TW` / `zh-CN` / `ja` / `ko`).
+- `timezone` — 날짜 표시용 IANA 시간대(예: `Asia/Seoul`).
+- `usageLimitTracking` — 실제 5시간 / 주간 쿼터 표시.
+- `advice.apiKey` — AI 조언 기능용 API 키(OpenAI 호환).
+- `pauseDashboardRefresh` — 대시보드 자동 새로고침 일시정지(대시보드 헤더에서도 토글 가능).
 
-## 🚀 사용법
+전체 설정 표는 [메인 README](README.md#configuration)를 참고하세요.
 
-### 상태바
+## 문제 해결
 
-- 펄스 아이콘과 함께 **오늘의 사용 비용** 표시
-- 클릭하여 상세한 분석 대시보드 열기
+**"No Claude Code Data"** — Claude Code가 설치되어 최소 한 번 사용되었는지 확인하고, `dataDirectory` 설정을 확인하세요(자동 감지는 `~/.claude/projects`를 봅니다).
 
-### 분석 대시보드
+**쿼터가 `5h:--% wk:--%`로 표시** — Claude Code에 한 번 로그인하세요. 확장은 `~/.claude/.credentials.json`을 읽기 전용으로 참조합니다.
 
-1. **시간 탭**: 오늘, 이번 달, 전체 기간 보기 간 전환
-2. **차트 지표**: 차트 위의 탭을 클릭하여 다양한 지표 간 전환:
-   - 비용 분석
-   - 입력/출력 토큰
-   - 캐시 생성/읽기 토큰
-   - 메시지 수
-3. **시간별 분석**: "오늘" 탭에서 시간별 사용 패턴 보기
-4. **확장 가능한 데이터**:
-   - "이번 달"의 일별 항목을 클릭하여 시간별 세부사항 보기
-   - "전체 기간"의 월별 항목을 클릭하여 일별 세부사항 보기
-5. **인터랙티브 테이블**: 차트 아래의 상세한 일별/월별 분석
-6. **모델 분석**: 각 탭의 모델별 사용 통계
+**이전 달 기록 누락** — Claude Code는 `cleanupPeriodDays`(기본 30일)보다 오래된 로그를 삭제합니다. 더 오래 보관하려면 `~/.claude/settings.json`에 `{ "cleanupPeriodDays": 365 }`를 설정하세요. 이미 삭제된 로그는 복구할 수 없습니다.
 
-![사용 흐름](images/usage-flow.png)
+**토큰 수가 프로바이더 대시보드보다 적음** — 일부 프록시 / 동적 워크플로는 에이전트별 기록을 하위 디렉터리에 쓰며 불완전할 수 있습니다. 실제 지출은 프로바이더 청구 페이지를 확인하세요. 네이티브 워크플로 귀속 기능은 계획 중입니다.
 
-## 📋 요구사항
+## 크레딧
 
-- **Claude Code**: 설치되고 실행 중이어야 합니다
-- **VSCode**: 버전 1.74.0 이상
-- **Node.js**: 내장 모듈만 사용 (외부 의존성 없음)
+[`jack21/ClaudeCodeUsage`](https://github.com/jack21/ClaudeCodeUsage)에서 포크. MIT 라이선스. 커뮤니티 기여는 [CHANGELOG.md](CHANGELOG.md)에 명시. 많은 코드 변경은 [Claude Code](https://claude.com/claude-code)의 도움으로 작성되었습니다.
 
-## 🛠️ 문제 해결
-
-### "Claude Code 데이터 없음" 오류
-
-1. Claude Code가 설치되고 사용되었는지 확인
-2. 확장 프로그램 설정에서 데이터 디렉토리 설정 확인
-3. Claude Code가 `~/.claude/projects` 또는 `~/.config/claude/projects`에서 사용 로그를 생성하고 있는지 확인
-
-### 차트가 업데이트되지 않음
-
-1. 다른 탭으로 전환했다가 다시 돌아와서 차트 새로고침
-2. 해당 기간에 실제 사용 데이터가 있는지 확인
-3. Claude 사용 기록에 캐시 토큰이 있는지 확인
-
-### 성능 문제
-
-- 속도 저하가 발생하면 새로고침 간격을 늘리세요
-- 확장 프로그램은 파일 I/O를 최소화하기 위해 1분 캐싱을 사용합니다
-
-## 📝 변경 사항
-
-### v1.0.8 (2025-11-28)
-
-- 📝 모든 코드 주석을 번체 중국어에서 영어로 변환
-- 🌍 코드 국제화 표준 향상
-- 🔧 코드 가독성 및 유지 관리 개선
-- 💰 새로운 Opus 4.5 / Haiku 4.5 가격이 포함된 가격표 수정 ([@mxzinke](https://github.com/mxzinke) 감사합니다)
-- 🇩🇪 독일어(de-DE) 번역 지원 추가 ([@mxzinke](https://github.com/mxzinke) 감사합니다)
-
-### v1.0.7 (2025-11-28)
-
-- 🌐 시간별 사용량 레이블에 대한 다국어 번역 지원 추가
-- 🔧 코드에서 하드코딩된 중국어 텍스트 제거 및 i18n 번역 시스템으로 대체
-- ✨ 사용자 인터페이스의 다국어 일관성 보장 (영어, 번체 중국어, 간체 중국어, 일본어, 한국어)
-
-### v1.0.6 (2025-08-10)
-
-- 🆕 Claude Opus 4.1 모델 가격 지원 추가
-- 🔄 `claude-opus-4-1-20250805` 및 `claude-opus-4-1` 모델 ID를 포함한 가격 데이터 업데이트
-- 📊 Opus 4와 동일한 가격 (입력 $15/1M, 출력 $75/1M 토큰)
-
-### v1.0.5 (2025-01)
-
-- ⏰ 시간별 사용량 통계 및 시각화 추가
-- 📈 시간별 세부 기능으로 대시보드 강화
-- 🔧 시간별 집계를 위한 데이터 처리 개선
-
-### v1.0.4 (2025-01)
-
-- 📊 전체 기간 데이터 계산 기능 추가
-- 🎨 차트와 레이블로 전체 기간 사용 데이터를 표시하도록 UI 업데이트
-- 🔄 새로운 데이터 구조를 지원하도록 데이터 업데이트 로직 수정
-- 🌐 다국어 지원에 "전체 기간" 번역 추가
-
-### v1.0.3 (2025-01)
-
-- 🔗 GitHub 저장소 URL 업데이트
-- 🖼️ README 이미지 링크를 새 저장소 위치로 수정
-- 📦 버전 업그레이드 및 저장소 마이그레이션
-
-### v1.0.0 (2025-01)
-
-- 🎉 최초 완전 릴리스 버전
-- 📊 상태 표시줄에서 실시간 Claude Code 사용량 모니터링
-- 🌐 다국어 지원 (English, 繁體中文, 简体中文, 日本語, 한국어)
-- 📈 차트와 테이블이 포함된 인터랙티브 분석 대시보드
-- 🎨 VSCode 테마 통합 및 반응형 디자인
-- ⚙️ 구성 가능한 새로 고침 간격 및 설정
+**이슈, PR, 아이디어를 환영합니다** —— 그것이 프로젝트가 성장하는 방식입니다.
 
 ## 라이선스
 
-MIT
-
-## 기여
-
-GitHub 저장소에서 Issue와 Pull Request를 환영합니다.
+[MIT](LICENSE)

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -1,199 +1,184 @@
 # Claude Code 使用量监控
 
-🌐 **Language | 語言 | 言語 | 언어**: [🏠 Main](README.md) | [English](README-en.md) | [繁體中文](README-zh-TW.md) | **简体中文** | [日本語](README-ja.md) | [한국어](README-ko.md)
+🌐 **语言**: [🏠 Main](README.md) | [English](README-en.md) | [繁體中文](README-zh-TW.md) | **简体中文** | [日本語](README-ja.md) | [한국어](README-ko.md)
 
 ---
 
 **看清你的 Claude Code 用量，让 AI 帮你用得更好。** 不是账单工具，不是多 provider 监控面板。一个专注于 token 精确归因、并用 AI 帮你优化使用习惯的轻量 VS Code 插件。
 
-## 🖼️ 截图
+> **它是什么**：一个 VS Code 状态栏小工具，读取本地 Claude Code 对话日志，按 token × 公开单价估算用量与成本；并提供可选的 AI 建议功能，帮你优化提示词、减少不必要的 token 消耗。
+>
+> **它不是什么**：账单工具。显示金额均为估算值（基于公开的每百万 token 单价），实际费用请以 Anthropic 官方账单为准。
+
+> 截图取自英文界面。
+
+---
+
+## 截图
 
 ### 状态栏
 
-![状态栏预览](https://raw.githubusercontent.com/jack21/ClaudeCodeUsage/refs/heads/main/images/status-bar-preview.jpg)
+![状态栏](images/v2-status-bar-en.png)
+
+*今日成本 · 当前 session 成本 · 5 小时和每周配额利用率。*
+
+将鼠标移到配额指示器上可看到明细：
+
+![配额提示](images/v2-quota-en.png)
+
+*来自真实 `/usage` 数据 —— 利用率百分比、重置倒计时，以及每周重置的星期与时间。*
 
 ### 仪表板
 
-![仪表板预览](https://raw.githubusercontent.com/jack21/ClaudeCodeUsage/refs/heads/main/images/dashboard-preview.jpg)
+![仪表板](images/v2-dashboard-en.png)
 
-## ✨ 功能特色
+*点击状态栏打开完整仪表板。堆叠成本构成图、小时分布、缓存命中率、按 token 类型的成本构成，以及下方的按模型 / 按日表格。*
 
-### 📊 实时监控
+### Content 标签页 —— 看清 token 究竟花在哪
 
-- **状态栏显示**：在 VSCode 状态栏显示今日使用成本
-- **实时更新**：自动数据刷新，可配置更新间隔（最少 30 秒）
-- **零外部依赖**：使用原生 Node.js 模块，确保最大兼容性
+![Content 标签页](images/v2-content-en.png)
 
-### 📈 交互式分析仪表板
+*估算哪些内容消耗你的 token —— 你的提示 vs 工具结果（按工具）vs 助手输出 / 思考。这是优化使用的着力点，统计范围为近 30 天。*
 
-- **多重时间视图**：今日、本月和所有时间的使用视角
-- **交互式图表**：可切换的柱状图表，支持 6 种不同指标：
-  - 成本分析
-  - 输入/输出 tokens
-  - 缓存创建/读取 tokens
-  - 消息数量
-- **每小时使用量分析**：提供今日及特定日期的详细每小时使用分析
-- **可展开的月度数据**：点击"所有时间"中的任何月份查看每日明细
-- **详细表格**：完整的每日/每月使用量分析，支持向下深入查询
-- **模型分析**：各模型的成本和 token 消耗跟踪
+### AI 建议（可选）
 
-![仪表板预览](images/dashboard-preview.png)
+![AI 建议](images/v2-advice-en.png)
 
-### 🌐 多语言支持
+*可选的 AI 顾问，将你的用量汇总加上近期提示的样本发往 OpenAI 兼容 API（默认 DeepSeek V4 Pro），给出具体改写建议。需自备 key，或先点击 `Preview demo` 预览静态示例。*
 
-- **5 种语言**：English, 繁體中文, 简体中文, 日本語, 한국어
-- **自动检测**：自动检测系统语言
-- **手动覆盖**：在设置中选择偏好语言
+---
 
-### 🎨 视觉功能
+## 2.0 新功能
 
-- **自下而上图表**：符合行业标准的图表方向
-- **月度趋势**：所有时间视图显示月度聚合数据，便于长期趋势分析
-- **VSCode 主题集成**：完美配合浅色/深色主题
-- **响应式设计**：针对不同屏幕尺寸优化
+- **真实的 5 小时和每周配额** 显示在状态栏 —— 读取 Claude Code 现有的 OAuth 会话（`~/.claude/.credentials.json`），无需配置。借鉴上游 [PR #9](https://github.com/jack21/ClaudeCodeUsage/pull/9)（[@Dobidop](https://github.com/Dobidop)）。
+- **四个新标签页**：Sessions、Projects、Content、Branches，均可排序。
+- **堆叠成本构成图**，含 Y 轴和参考线。
+- **AI 建议命令**（默认 DeepSeek V4 Pro，`reasoning_effort=max`），未配置 key 时提供示例演示。
+- **多厂商定价**：Opus 4.x、Sonnet 4.x、Haiku 4.5 对照 Anthropic 官方定价；OpenAI、Gemini、DeepSeek、Kimi、GLM、Qwen 等代理场景的参考价，含家族感知回退。`Refresh Token Pricing` 可拉取 LiteLLM 即时价格。
+- **自定义时区** 用于日期显示（`claudeCodeUsage.timezone`）。
+- **浅色主题标签可读性** 修复。
+- 全程 **locale 感知的数字与日期**（德语用 `.`，英语用 `,`）。
+- **实时状态栏**：基于 `fs.watch`（1.5s 防抖）+ 空闲跳过 + 非阻塞加载（每 25 个文件让出事件循环）。
 
-## 📥 下载
+完整变更：[CHANGELOG.md](CHANGELOG.md)。关闭上游 issue [#7](https://github.com/jack21/ClaudeCodeUsage/issues/7)、[#10](https://github.com/jack21/ClaudeCodeUsage/issues/10)、[#11](https://github.com/jack21/ClaudeCodeUsage/issues/11)、[#13](https://github.com/jack21/ClaudeCodeUsage/issues/13)。
 
-### VSCode Marketplace
-
-[![VSCode Marketplace](https://img.shields.io/visual-studio-marketplace/v/growthjack.claude-code-usage?style=for-the-badge&logo=visual-studio-code&label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=growthjack.claude-code-usage)
-
-### Open VSX Registry（适用于 Cursor / Windsurf / Antigravity）
-
-[![Open VSX](https://img.shields.io/open-vsx/v/GrowthJack/claude-code-usage?style=for-the-badge&logo=eclipseide&label=Open%20VSX%20Registry)](https://marketplace.cursorapi.com/items/?itemName=GrowthJack.claude-code-usage)
+---
 
 ## 安装
 
-1. 从 VSCode 市场安装扩展
-2. 扩展会自动检测您的 Claude Code 数据目录
-3. 开始使用 Claude Code，您的使用量会出现在状态栏中
+### VS Code Marketplace
+
+在扩展视图（`Ctrl+Shift+X`）搜索 **`Claude Code Usage`**，或：
+
+```
+ext install GrowthJack.claude-code-usage
+```
+
+### Cursor / Windsurf / Antigravity（Open VSX）
+
+同一扩展也发布在 [Open VSX Registry](https://open-vsx.org/extension/GrowthJack/claude-code-usage)。
+
+### 从 `.vsix` 文件安装
+
+`Ctrl+Shift+P` → **Extensions: Install from VSIX...** → 选择下载的 `.vsix`。
+
+---
 
 ## 配置
 
-通过 `文件 > 首选项 > 设置` 并搜索「Claude Code Usage」来访问设置：
+打开设置（`Ctrl+,`）搜索 **`Claude Code Usage`**。所有设置均为可选，默认值在合理范围内保持上游行为。
 
-- **刷新间隔**：更新使用数据的频率（最少 30 秒）
-- **数据目录**：自定义 Claude 数据目录路径（留空以自动检测）
-- **语言**：显示语言偏好
-- **小数位数**：成本显示的小数位数
+| 设置 | 默认 | 作用 |
+|---|---|---|
+| `refreshInterval` | `60` | 刷新间隔（秒，最小 30）。 |
+| `dataDirectory` | `""` | 自定义 Claude 数据目录；留空则自动检测。 |
+| `language` | `"auto"` | 界面语言：`auto` / `en` / `zh-TW` / `zh-CN` / `ja` / `ko`。 |
+| `decimalPlaces` | `2` | 成本显示的小数位（0–4）。 |
+| `compactNumbers` | `false` | 用 `1.2M` / `345K` 代替完整数字。 |
+| `timezone` | `""` | 日期显示用的 IANA 时区（如 `Asia/Hong_Kong`）。 |
+| `usageLimitTracking` | `true` | 在状态栏显示真实 5h / 每周配额。 |
+| `enableContentAnalysis` | `true` | 运行 Content 标签页的 token 分析。 |
+| `projectGroupingMode` | `"git"` | Projects 标签分组：`git` / `folder` / `flat`。 |
+| `pauseDashboardRefresh` | `false` | 暂停仪表板自动刷新（也可在仪表板标题栏切换）。 |
+| `fileWatching` | `true` | 启用基于 `fs.watch` 的实时刷新；关闭则仅按间隔刷新。 |
+| `advice.apiKey` | `""` | AI 建议功能的 API key（OpenAI 兼容）。 |
+| `advice.apiUrl` | `https://api.deepseek.com/chat/completions` | chat-completions 端点。 |
+| `advice.model` | `"deepseek-v4-pro"` | 模型名称。 |
+| `advice.reasoningEffort` | `"max"` | 推理强度（DeepSeek V4：`high` / `max`）。 |
 
-## 🚀 使用方式
+---
 
-### 状态栏
+## 成本是如何计算的
 
-- 显示**今日使用成本**，附带脉冲图标
-- 点击打开详细分析仪表板
+状态栏成本为 **`Σ (tokens × 每百万单价)`**，覆盖输入、输出、缓存写入、缓存读取，并按模型汇总。
 
-### 分析仪表板
+- **每百万单价** 来自内置定价表，对照 Anthropic 官方定价页验证，并为可能出现在代理场景的非 Anthropic 模型补充参考价。
+- **`Refresh Token Pricing`**（命令 + 仪表板按钮）从 [LiteLLM 公开数据集](https://github.com/BerriAI/litellm)拉取即时价格作为运行时覆盖。
+- **未知模型快照** 按其所属家族（Opus / Sonnet / Haiku / GPT / Gemini / DeepSeek / Kimi / GLM / Qwen）的当前档位定价，而非盲目回退。
 
-1. **时间标签**：在今日、本月和所有时间视图之间切换
-2. **图表指标**：点击图表上方的标签切换不同指标：
-   - 成本分析
-   - 输入/输出 tokens
-   - 缓存创建/读取 tokens
-   - 消息数量
-3. **每小时分析**：在"今日"标签中查看每小时使用模式
-4. **可展开数据**：
-   - 点击"本月"中的每日项目可查看每小时明细
-   - 点击"所有时间"中的每月项目可查看每日明细
-5. **交互式表格**：图表下方的详细每日/每月分析
-6. **模型分析**：各标签中的模型使用统计
+状态栏**不知道**：
 
-![使用流程](images/usage-flow.png)
+- 你实际的 Anthropic 账单（折扣、免费额度、套餐上限）。
+- 你的代理供应商是否采用不同费率。
+- 任何未记录在本地 `.jsonl` 日志中的内容。
 
-## 📋 系统要求
+**5h / 每周配额指示器**则不同 —— 它通过 OAuth 会话查询 Claude Code 真实的 `/usage` 端点，显示 Anthropic 为你的账户记录的实际百分比。该数值是权威的。
 
-- **Claude Code**：必须安装并运行
-- **VSCode**：1.74.0 或更新版本
-- **Node.js**：仅使用内置模块（无外部依赖）
+---
 
-## 🛠️ 故障排除
+## 隐私
 
-### "无 Claude Code 数据"错误
+- 所有 token / 成本 / session 分析都在**本地**进行，读取你的 `~/.claude/projects/**/*.jsonl` 文件。
+- 配额指示器用 Claude Code 现有的 OAuth token 调用 **`api.anthropic.com/api/oauth/usage`**，不发送任何额外凭证。
+- **AI 建议命令** 是唯一会调用外部服务的功能 —— 且仅在*你*主动触发时。它将用量汇总加上近期提示样本发往你在 `advice.apiUrl` 配置的端点。**需自备 key**，扩展本身不附带任何 key。未配置 key 时，命令会打开一份手写示例，而不调用任何 API。
 
-1. 确保已安装并使用过 Claude Code
-2. 检查扩展首选项中的数据目录设置
-3. 验证 Claude Code 正在 `~/.claude/projects` 或 `~/.config/claude/projects` 生成使用记录
+---
 
-### 图表不更新
+## 疑难排解
 
-1. 切换到不同标签再切回来刷新图表
-2. 检查该时间段是否有实际使用数据
-3. 验证 Claude 使用记录中是否有缓存 tokens
+**"无 Claude Code 数据"**
+- 确认 Claude Code 已安装并至少使用过一次。
+- 检查 `dataDirectory` 设置；自动检测会查 `~/.claude/projects` 和 `~/.config/claude/projects`。
 
-### 性能问题
+**配额行显示 `5h:--% wk:--%`**
+- `~/.claude/.credentials.json` 中的 OAuth token 缺失或过期。登录 Claude Code 一次即可；扩展以只读方式读取凭证文件，并在需要时刷新 bearer。
 
-- 如遇到速度变慢，可增加刷新间隔
-- 扩展使用 1 分钟缓存来减少文件 I/O
+**`Get AI Usage Advice` 返回 404**
+- DeepSeek 当前端点**不**使用 `/v1` 前缀。请用 `https://api.deepseek.com/chat/completions`。扩展会自动剥除多余的 `/v1`。
 
-### 历史记录消失或缺少早期月份数据
+**`Get AI Usage Advice` 显示示例而非真实建议**
+- 说明未在 `claudeCodeUsage.advice.apiKey` 配置 API key。示例文件名带 `…-DEMO-…` 标记并有醒目横幅。在设置中填入 key 后重新运行命令。
 
-Claude Code 会自动删除超过 `cleanupPeriodDays`（默认 **30 天**）的对话日志。已删除的记录无法恢复。要保留更多历史，请在 `~/.claude/settings.json` 中添加：
+**大历史下刷新缓慢**
+- 2.0 每 25 个文件让出一次事件循环；空闲时跳过重算。如仍有问题，提高 `refreshInterval` 或将 `enableContentAnalysis` 设为 `false`。
 
-```json
-{ "cleanupPeriodDays": 365 }
-```
+**历史记录消失或缺少早期月份**
+- Claude Code 会自动删除超过 `cleanupPeriodDays`（默认 **30 天**）的对话日志。已删除的记录无法恢复。要保留更多历史，在 `~/.claude/settings.json` 中添加：
+  ```json
+  { "cleanupPeriodDays": 365 }
+  ```
+  此设置仅对之后生成的日志有效。感谢 [@nickearnshaw](https://github.com/nickearnshaw)（[PR #21](https://github.com/jack21/ClaudeCodeUsage/pull/21)）记录此项。
 
-此设置仅对之后生成的日志有效，已删除的记录无法找回。
+**Token 数量低于模型提供商后台**
+- 如果你通过第三方代理使用 Claude Code，且请求经由 sub-agent 或后台 workflow（如 ultracode / 动态工作流），每个 agent 会在子目录写入独立的 `.jsonl` 文件。扩展会读取所有这些文件，但部分代理配置可能根本不写 agent 级记录。在未来版本加入原生工作流归因之前，此处显示的总量可能低于供应商的上游统计。实际消费始终以你的供应商账单页面为准。
 
-### Token 数量低于第三方提供商后台显示
+---
 
-如果你通过代理（如 CC Switch）使用动态工作流（ultracode / workflow），每个子 agent 会将记录写入子目录下独立的 `.jsonl` 文件。插件会扫描这些文件，但部分代理配置可能不会写入 agent 级别的记录，导致统计数量偏低。实际消费请以提供商账单为准，后续版本将改进工作流归因展示。
+## 致谢
 
-## 📝 版本更新日志
+Fork 自 [`jack21/ClaudeCodeUsage`](https://github.com/jack21/ClaudeCodeUsage)。MIT 授权。
 
-### v1.0.8 (2025-11-28)
+- [@Dobidop](https://github.com/Dobidop) —— [PR #9](https://github.com/jack21/ClaudeCodeUsage/pull/9)，读取真实 `/usage` 数据的 OAuth 方案。本版配额指示器借鉴自该工作。
+- [@nickearnshaw](https://github.com/nickearnshaw) —— [PR #8](https://github.com/jack21/ClaudeCodeUsage/pull/8) locale 感知的数字/日期格式；[PR #20](https://github.com/jack21/ClaudeCodeUsage/pull/20) 修复 webview/状态栏卡在 "Loading…"（重入保护 + 仅冷启动显示加载动画）；[PR #21](https://github.com/jack21/ClaudeCodeUsage/pull/21) 关于 `cleanupPeriodDays` 的文档。
+- [@brenoneill](https://github.com/brenoneill) —— [PR #14](https://github.com/jack21/ClaudeCodeUsage/pull/14)，自定义数据目录（已并入上游 1.0.8）。
+- [@mxzinke](https://github.com/mxzinke) —— Opus 4.5 / Haiku 4.5 价格 + 德语翻译（上游 1.0.8）。
 
-- 📝 将所有代码注释从繁体中文改为英文
-- 🌍 提升代码的国际化标准
-- 🔧 优化代码可读性与维护性
-- 💰 修正定价表，加入新的 Opus 4.5 / Haiku 4.5 价格（感谢 [@mxzinke](https://github.com/mxzinke)）
-- 🇩🇪 新增德语（de-DE）翻译支持（感谢 [@mxzinke](https://github.com/mxzinke)）
+本 fork 中许多代码改动由 [Claude Code](https://claude.com/claude-code) 协助起草（commit 含 `Co-Authored-By: Claude <noreply@anthropic.com>`）。
 
-### v1.0.7 (2025-11-28)
+**欢迎提出 Issue、PR 与想法** —— 这正是项目成长的方式。
 
-- 🌐 新增每小时使用量标签的多语言翻译支持
-- 🔧 移除代码中硬编码的中文文字，改用 i18n 翻译系统
-- ✨ 确保用户界面的多语言一致性（英文、繁体中文、简体中文、日文、韩文）
-
-### v1.0.6 (2025-08-10)
-
-- 🆕 新增 Claude Opus 4.1 模型定价支持
-- 🔄 更新定价数据以包含 `claude-opus-4-1-20250805` 和 `claude-opus-4-1` 模型 ID
-- 📊 定价与 Opus 4 相同（$15/1M 输入，$75/1M 输出 tokens）
-
-### v1.0.5 (2025-01)
-
-- ⏰ 新增每小时使用量统计与可视化
-- 📈 增强仪表板的每小时细分功能
-- 🔧 改善每小时汇总的数据处理
-
-### v1.0.4 (2025-01)
-
-- 📊 新增全时间数据计算功能
-- 🎨 更新 UI 以显示全时间使用数据与图表和标签
-- 🔄 修正数据更新逻辑以支持新数据结构
-- 🌐 在多语言支持中新增「全时间」翻译
-
-### v1.0.3 (2025-01)
-
-- 🔗 更新 GitHub 仓库 URL
-- 🖼️ 修正 README 图片链接指向新仓库位置
-- 📦 版本升级与仓库迁移
-
-### v1.0.0 (2025-01)
-
-- 🎉 首次完整发行版
-- 📊 状态栏实时 Claude Code 使用量监控
-- 🌐 多语言支持（English, 繁體中文, 简体中文, 日本語, 한국어）
-- 📈 交互式分析仪表板与图表和表格
-- 🎨 VSCode 主题整合与响应式设计
-- ⚙️ 可设定的重新整理间隔与设定
+---
 
 ## 许可证
 
-MIT
-
-## 贡献
-
-欢迎在 GitHub 仓库提出 Issue 和 Pull Request。
+[MIT](LICENSE)

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -1,185 +1,79 @@
 # Claude Code 使用量監控
 
-🌐 **Language | 語言 | 言語 | 언어**: [🏠 Main](README.md) | [English](README-en.md) | **繁體中文** | [简体中文](README-zh-CN.md) | [日本語](README-ja.md) | [한국어](README-ko.md)
+🌐 **語言**: [🏠 Main](README.md) | [English](README-en.md) | **繁體中文** | [简体中文](README-zh-CN.md) | [日本語](README-ja.md) | [한국어](README-ko.md)
 
 ---
 
-看清你的 Claude Code 用量，讓 AI 幫你用得更好。不是帳單工具，不是多 provider 監控面板。一個專注於 token 精確歸因、並以 AI 幫你優化使用習慣的輕量 VS Code 插件。
+**看清你的 Claude Code 用量，讓 AI 幫你用得更好。** 不是帳單工具，不是多 provider 監控面板。一個專注於 token 精確歸因、並以 AI 幫你優化使用習慣的輕量 VS Code 插件。
 
-## 🖼️ 截圖
+> **它是什麼**：一個 VS Code 狀態列小工具，讀取本地 Claude Code 對話日誌，按 token × 公開單價估算用量與成本；並提供可選的 AI 建議功能，幫你優化提示詞、減少不必要的 token 消耗。
+>
+> **它不是什麼**：帳單工具。顯示金額均為估算值，實際費用請以官方帳單為準。
+
+> 截圖取自英文介面。完整功能說明請見[主 README](README.md)。
+
+## 截圖
 
 ### 狀態列
 
-![狀態列預覽](https://raw.githubusercontent.com/jack21/ClaudeCodeUsage/refs/heads/main/images/status-bar-preview.jpg)
+![狀態列](images/v2-status-bar-en.png)
+
+將滑鼠移到配額指示器上可看到明細：
+
+![配額提示](images/v2-quota-en.png)
 
 ### 儀表板
 
-![儀表板預覽](https://raw.githubusercontent.com/jack21/ClaudeCodeUsage/refs/heads/main/images/dashboard-preview.jpg)
+![儀表板](images/v2-dashboard-en.png)
 
-## ✨ 功能特色
+## 功能特色
 
-### 📊 即時監控
-
-- **狀態列顯示**：在 VSCode 狀態列顯示今日使用成本
-- **即時更新**：自動資料更新，可設定更新間隔（最少 30 秒）
-- **零外部依賴**：使用原生 Node.js 模組，確保最大相容性
-
-### 📈 互動式分析儀表板
-
-- **多重時間檢視**：今日、本月和所有時間的使用角度
-- **互動式圖表**：可切換的柱狀圖表，支援 6 種不同指標：
-  - 成本分析
-  - 輸入/輸出 tokens
-  - 快取建立/讀取 tokens
-  - 訊息數量
-- **每小時使用量分析**：提供今日及特定日期的詳細每小時使用分析
-- **可展開的月度資料**：點擊「所有時間」中的任何月份檢視每日明細
-- **詳細表格**：完整的每日/每月使用量分析，支援向下深入查詢
-- **模型分析**：各模型的成本和 token 消耗追蹤
-
-![儀表板預覽](images/dashboard-preview.png)
-
-### 🌐 多語言支援
-
-- **5 種語言**：English, 繁體中文, 简体中文, 日本語, 한국어
-- **自動偵測**：自動偵測系統語言
-- **手動覆蓋**：在設定中選擇偏好語言
-
-### 🎨 視覺功能
-
-- **由下而上圖表**：符合業界標準的圖表方向
-- **月度趨勢**：所有時間檢視顯示月度聚合資料，便於長期趨勢分析
-- **VSCode 主題整合**：完美配合亮色/暗色主題
-- **響應式設計**：針對不同螢幕尺寸最佳化
-
-## 📥 下載
-
-### VSCode Marketplace
-
-[![VSCode Marketplace](https://img.shields.io/visual-studio-marketplace/v/growthjack.claude-code-usage?style=for-the-badge&logo=visual-studio-code&label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=growthjack.claude-code-usage)
-
-### Open VSX Registry（適用於 Cursor / Windsurf / Antigravity）
-
-[![Open VSX](https://img.shields.io/open-vsx/v/GrowthJack/claude-code-usage?style=for-the-badge&logo=eclipseide&label=Open%20VSX%20Registry)](https://marketplace.cursorapi.com/items/?itemName=GrowthJack.claude-code-usage)
+- **狀態列** — 今日成本、當前 session 成本，以及真實的 5 小時 / 每週配額（`5h:N% wk:N%`），透過 Claude Code 自身的 OAuth 工作階段讀取，無需設定。
+- **儀表板分頁** — 今日 / 本月 / 全部時間，外加 **Sessions / Projects / Content / Branches**，皆可排序。
+- **堆疊式成本構成圖**，含 Y 軸與參考線 —— 一眼看出每日 / 每月的成本中，輸入、輸出、快取寫入、快取讀取各佔多少。
+- **Content 分頁** — 估算哪些內容消耗你的 token（你的提示 vs 工具結果 vs 助理輸出 / 思考）。
+- **AI 建議**（選用）— 將用量摘要加上你近期提示的樣本送往 OpenAI 相容 API（預設 DeepSeek V4 Pro），給出具體改寫建議。需自備 key，或先預覽靜態示範。
+- **多廠商定價** — Opus 4.x / Sonnet 4.x / Haiku 4.5 對照 Anthropic 官方定價；OpenAI / Gemini / DeepSeek / Kimi / GLM / Qwen 參考價，含家族感知回退。`Refresh Token Pricing` 可拉取 LiteLLM 即時價格。
+- **個人化** — 語言、時區、小數位數、精簡數字、專案分組、儀表板自動刷新開關。
 
 ## 安裝
 
-1. 從 VSCode 市集安裝擴充功能
-2. 擴充功能會自動偵測您的 Claude Code 資料目錄
-3. 開始使用 Claude Code，您的使用量會出現在狀態列中
+在擴充功能檢視（`Ctrl+Shift+X`）搜尋 **`Claude Code Usage`**，或：
+
+```
+ext install GrowthJack.claude-code-usage
+```
+
+也發佈於 [Open VSX Registry](https://open-vsx.org/extension/GrowthJack/claude-code-usage)，供 Cursor / Windsurf 使用。
 
 ## 設定
 
-透過 `檔案 > 喜好設定 > 設定` 並搜尋「Claude Code Usage」來存取設定：
+開啟設定（`Ctrl+,`）並搜尋 **`Claude Code Usage`**。所有設定皆為選用，最常用的：
 
-- **重新整理間隔**：更新使用資料的頻率（最少 30 秒）
-- **資料目錄**：自訂 Claude 資料目錄路徑（留空以自動偵測）
-- **語言**：顯示語言偏好
-- **小數位數**：成本顯示的小數位數
+- `language` — 介面語言（`auto` / `en` / `zh-TW` / `zh-CN` / `ja` / `ko`）。
+- `timezone` — 日期顯示用的 IANA 時區（如 `Asia/Hong_Kong`）。
+- `usageLimitTracking` — 顯示真實的 5 小時 / 每週配額指示器。
+- `advice.apiKey` — AI 建議功能的 API key（OpenAI 相容）。
+- `pauseDashboardRefresh` — 暫停儀表板自動刷新（也可在儀表板標題列切換）。
 
-## 🚀 使用方式
+完整設定表請見[主 README](README.md#configuration)。
 
-### 狀態列
+## 疑難排解
 
-- 顯示**今日使用成本**，附帶脈衝圖示
-- 點擊開啟詳細分析儀表板
+**「無 Claude Code 資料」** — 確認 Claude Code 已安裝並至少使用過一次；檢查 `dataDirectory` 設定（自動偵測會查 `~/.claude/projects`）。
 
-### 分析儀表板
+**配額顯示 `5h:--% wk:--%`** — 登入 Claude Code 一次即可；插件以唯讀方式讀取 `~/.claude/.credentials.json`。
 
-1. **時間分頁**：在今日、本月和所有時間檢視之間切換
-2. **圖表指標**：點擊圖表上方的分頁切換不同指標：
-   - 成本分析
-   - 輸入/輸出 tokens
-   - 快取建立/讀取 tokens
-   - 訊息數量
-3. **每小時分析**：在「今日」分頁中檢視每小時使用模式
-4. **可展開資料**：
-   - 點擊「本月」中的每日項目可檢視每小時明細
-   - 點擊「所有時間」中的每月項目可檢視每日明細
-5. **互動式表格**：圖表下方的詳細每日/每月分析
-6. **模型分析**：各分頁中的模型使用統計
+**缺少較早月份的歷史** — Claude Code 會刪除超過 `cleanupPeriodDays`（預設 30 天）的日誌。若要保留更多，在 `~/.claude/settings.json` 設定 `{ "cleanupPeriodDays": 365 }`。已刪除的日誌無法復原。
 
-![使用流程](images/usage-flow.png)
+**Token 數低於供應商後台** — 部分代理 / 動態工作流會將各 agent 記錄寫入子目錄，可能不完整。實際消費請以供應商帳單為準。原生工作流歸因功能規劃中。
 
-## 📋 系統需求
+## 致謝
 
-- **Claude Code**：必須安裝並執行
-- **VSCode**：1.74.0 或更新版本
-- **Node.js**：僅使用內建模組（無外部依賴）
+Fork 自 [`jack21/ClaudeCodeUsage`](https://github.com/jack21/ClaudeCodeUsage)。MIT 授權。社群貢獻致謝見 [CHANGELOG.md](CHANGELOG.md)。許多程式碼改動由 [Claude Code](https://claude.com/claude-code) 協助起草。
 
-## 🛠️ 疑難排解
-
-### 「無 Claude Code 資料」錯誤
-
-1. 確保已安裝並使用過 Claude Code
-2. 檢查擴充功能偏好設定中的資料目錄設定
-3. 驗證 Claude Code 正在 `~/.claude/projects` 或 `~/.config/claude/projects` 產生使用記錄
-
-### 圖表不更新
-
-1. 切換到不同分頁再切回來重新整理圖表
-2. 檢查該時間段是否有實際使用資料
-3. 驗證 Claude 使用記錄中是否有快取 tokens
-
-### 效能問題
-
-- 如遇到速度變慢，可增加重新整理間隔
-- 擴充功能使用 1 分鐘快取來減少檔案 I/O
+**歡迎提出 Issue、PR 與想法** —— 這正是專案成長的方式。
 
 ## 授權
 
-MIT
-
-## 📝 版本更新日誌
-
-### v1.0.8 (2025-11-28)
-
-- 📝 將所有程式碼註解從繁體中文改為英文
-- 🌍 提升程式碼的國際化標準
-- 🔧 優化程式碼可讀性與維護性
-- 💰 修正定價表，加入新的 Opus 4.5 / Haiku 4.5 價格（感謝 [@mxzinke](https://github.com/mxzinke)）
-- 🇩🇪 新增德語（de-DE）翻譯支援（感謝 [@mxzinke](https://github.com/mxzinke)）
-
-### v1.0.7 (2025-11-28)
-
-- 🌐 新增每小時使用量標籤的多語言翻譯支援
-- 🔧 移除程式碼中硬編碼的中文文字，改用 i18n 翻譯系統
-- ✨ 確保使用者界面的多語言一致性（英文、繁體中文、简体中文、日文、韓文）
-
-### v1.0.6 (2025-08-10)
-
-- 🆕 新增 Claude Opus 4.1 模型訂價支援
-- 🔄 更新訂價資料以包含 `claude-opus-4-1-20250805` 和 `claude-opus-4-1` 模型 ID
-- 📊 訂價與 Opus 4 相同（$15/1M 輸入，$75/1M 輸出 tokens）
-
-### v1.0.5 (2025-07)
-
-- ⏰ 新增每小時使用量統計與視覺化
-- 📈 增強儀表板的每小時細分功能
-- 🔧 改善每小時彙總的資料處理
-
-### v1.0.4 (2025-07)
-
-- 📊 新增全時間資料計算功能
-- 🎨 更新 UI 以顯示全時間使用資料與圖表和標籤
-- 🔄 修正資料更新邏輯以支援新資料結構
-- 🌐 在多語言支援中新增「全時間」翻譯
-
-### v1.0.3 (2025-07)
-
-- 🔗 更新 GitHub 儲存庫 URL
-- 🖼️ 修正 README 圖片連結指向新儲存庫位置
-- 📦 版本升級與儲存庫遷移
-
-### v1.0.0 (2025-07)
-
-- 🎉 首次完整發行版
-- 📊 狀態列即時 Claude Code 使用量監控
-- 🌐 多語言支援（English, 繁體中文, 简体中文, 日本語, 한국어）
-- 📈 互動式分析儀表板與圖表和表格
-- 🎨 VSCode 主題整合與響應式設計
-- ⚙️ 可設定的重新整理間隔與設定
-
-## 貢獻
-
-歡迎在 GitHub 儲存庫提出 Issue 和 Pull Request。
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ use Claude Code better.
 >
 > **它不是什么**：账单工具。显示金额均为估算值，实际费用请以官方账单为准。
 
-🌐 **Multi-language documentation** (v1 content; v2 translations in 2.0.1):
+🌐 **Multi-language documentation**:
 [English](README-en.md) ·
 [繁體中文](README-zh-TW.md) ·
 [简体中文](README-zh-CN.md) ·
@@ -96,7 +96,7 @@ on the warning prompt to see a static example first.*
 - **Real-time status bar** via `fs.watch` (1.5 s debounce) + idle-aware
   refresh + non-blocking loader (yields every 25 files).
 
-Full changelog: [changelog.md](changelog.md).
+Full changelog: [CHANGELOG.md](CHANGELOG.md).
 Closes upstream issues
 [#7](https://github.com/jack21/ClaudeCodeUsage/issues/7),
 [#10](https://github.com/jack21/ClaudeCodeUsage/issues/10),
@@ -276,7 +276,7 @@ Many code changes in this fork were drafted with assistance from
 
 ## Changelog
 
-The current changelog lives in [**changelog.md**](changelog.md). The
+The current changelog lives in [**CHANGELOG.md**](CHANGELOG.md). The
 most recent 2.0 entry summarises every feature, fix and personalisation
 option in this release.
 

--- a/docs/V2.1-WORKFLOW-SPEC.md
+++ b/docs/V2.1-WORKFLOW-SPEC.md
@@ -1,0 +1,254 @@
+# V2.1.0 Implementation Spec — Workflow / Sub-agent Attribution
+
+> **How to use this document:** open a fresh Claude Code session on a clean
+> `feature/workflow-attribution` branch (cut from `main` after v2.0.2 merges)
+> and hand it this file with: *"Implement docs/V2.1-WORKFLOW-SPEC.md. Work
+> phase by phase; compile after each phase; stop and report after Phase 2 for
+> a checkpoint review."* Everything an implementer needs is in here — the why,
+> the data formats, the file map, acceptance criteria, and known traps.
+
+---
+
+## 1. Goal and product framing
+
+Claude Code's dynamic workflows (trigger word **ultracode**) dispatch tens to
+hundreds of background sub-agents. Each sub-agent writes its own usage log.
+**Today the extension reads those logs but cannot attribute them**: a single
+observed ultracode run produced 879 sub-agent records / 24.6M tokens versus
+77 records / 4.6M tokens in the main session — the sub-agent share (~84%) is
+invisible to the user as a *workflow*, and was historically miscounted.
+
+v2.1.0 makes workflow consumption a first-class, visible thing, in line with
+the product positioning (see `CLAUDE.md`): **token precision over cost
+precision; help the user decide what's worth using**. Keep every UI addition
+minimal — workflow-level summaries first, drill-down on demand.
+
+Non-goals for v2.1.0: multi-provider dashboards, billing reconciliation,
+historical data migration, settings webview.
+
+## 2. Data formats (verified on disk, 2026-06)
+
+### 2.1 Directory layout
+
+```
+~/.claude/projects/
+└── <proj-encoded>/                          e.g. d--Jiaming-PolyU-research
+    ├── <session-id>.jsonl                   main conversation
+    └── <session-id>/                        per-session asset dir
+        ├── subagents/
+        │   └── workflows/
+        │       └── wf_<id>/                 one dir per workflow run
+        │           ├── agent-<hex>.jsonl    per-sub-agent usage log  ★
+        │           ├── agent-<hex>.meta.json  agent metadata
+        │           └── journal.jsonl        workflow journal (no usage)
+        ├── workflows/
+        │   ├── wf_<id>.json                 workflow definition  ★
+        │   └── scripts/<name>-wf_<id>.js    generated script
+        └── tool-results/…                   misc artifacts (ignore)
+```
+
+★ = required inputs for this feature.
+
+### 2.2 `agent-*.jsonl` records
+
+Same line format as the main conversation log: each usage line has
+`timestamp`, `message.usage.{input_tokens, output_tokens,
+cache_creation_input_tokens, cache_read_input_tokens}`, `message.model`,
+`message.id`, and usually `cwd`. Verified: agent records carry **real token
+values** (no zero-placeholder problem) for both native Claude and CC Switch /
+DeepSeek routing. `journal.jsonl` lines have **no** `message.usage` — the
+loader's validator already rejects them; do not special-case.
+
+**Trap:** sub-agents spawned with worktree isolation have a `cwd` pointing at
+a temporary git worktree, *not* the workspace folder. Workspace filtering by
+cwd therefore misses them. The loader (since v2.0.2) resolves the parent
+session and encoded project dir from the *file path* (`parseSessionInfo`), so
+**prefer path-derived attribution over cwd for workflow records**.
+
+### 2.3 `wf_<id>.json` (workflow definition)
+
+Read defensively (shape is not a stable API): expect at least an id; a
+human-readable name may exist in the JSON or can be derived from the script
+filename `scripts/<human-name>-wf_<id>.js` (e.g.
+`deep-literature-review-wf_fcfc35cc-5d5.js` → "deep-literature-review").
+Fallback display name: the `wf_<id>` string.
+
+### 2.4 Loader state you can rely on (already shipped in v2.0.2)
+
+- `findJsonlFiles` already walks recursively → agent files are already read.
+- `parseSessionInfo(filePath)` already maps nested files to the parent
+  `sessionId` + encoded project dir.
+- Records carry `_sessionId`, `_projectPath`, `_projectName`,
+  `_sessionTitle?`, `_gitBranch?`.
+- Diagnostic logging (`options.log`) prints per-refresh stats + models seen.
+
+## 3. Phases
+
+Execute in order. Compile (`npm run compile`) must be clean after each phase.
+One commit per phase, message style: see `git log` on main.
+
+### Phase 0 — AI-advice reliability (bug fix, ships even if later phases slip)
+
+**Problem:** `Get AI Usage Advice` intermittently fails with `terminated` or
+hangs at the progress notification (v2.0.0 fine; regression noticed during
+v2.0.2 testing). Root-cause hypotheses, in order: (a) network instability on
+Node fetch to `api.deepseek.com` (same class of problem as the Anthropic
+TLS-fingerprint issue solved in `claudeApiClient.ts` by shelling out to
+`curl`); (b) oversized request body — `buildAdviceSummary` includes up to 80
+prompts × 2500 chars.
+
+**Changes in `src/advisor.ts` (+ `src/extension.ts` where noted):**
+1. Add an `AbortController` timeout (default 120 s) around the fetch; on
+   abort, surface a clear "timed out" error instead of hanging forever.
+2. On fetch failure (network error, `terminated`, abort), retry once; if the
+   retry fails, fall back to the same `curl` transport pattern used in
+   `claudeApiClient.ts` (factor the curl helper out of `claudeApiClient.ts`
+   into a small shared `src/httpClient.ts` rather than duplicating it).
+3. Cap the summary payload: at most 40 prompts × 1500 chars each, and skip
+   the prompts section entirely above ~80 KB total.
+4. **User-message purity:** advice prompts must contain only top-level user
+   messages from main sessions. In the content analyzer's prompt collection
+   (`collectPrompt` in `dataLoader.ts`), skip records whose source file lies
+   under a `subagents/` directory (the loader knows the file path at parse
+   time — thread a flag through), and skip obvious agent-framework text
+   (lines starting with structured scaffolding, e.g. XML-ish tags).
+
+**Acceptance:** advice runs 5/5 times without hanging on a flaky network
+(simulate by pointing `advice.apiUrl` at a black-holed host — expect a clean
+timeout error, not a hang); prompts sample contains no sub-agent content.
+
+### Phase 1 — Workflow data model in the loader
+
+**`src/types.ts`:** add
+
+```ts
+export interface WorkflowUsage {
+  workflowId: string;          // "wf_fcfc35cc-5d5"
+  name: string;                // derived human name or the id
+  sessionId: string;           // parent session
+  projectPath: string;         // encoded project dir or cwd-derived path
+  projectName: string;
+  startTime: Date;             // min record timestamp across agents
+  endTime: Date;               // max record timestamp
+  agentCount: number;
+  data: UsageData;             // aggregated across all agent files
+  agents: { agentId: string; data: UsageData; startTime: Date; endTime: Date }[];
+}
+```
+
+**`src/dataLoader.ts`:**
+1. In the per-file loop, when a file path contains `/subagents/workflows/`,
+   extract `_workflowId` (the `wf_*` segment) and `_agentId` (file basename)
+   onto each record. Add both as optional fields on `ClaudeUsageRecord`.
+2. New `static getWorkflowBreakdown(records, limit = 50): WorkflowUsage[]` —
+   group by `_workflowId`, aggregate with the existing `calculateUsageData`,
+   sort by `endTime` desc. Resolve `name` by checking (cheap, cached per
+   refresh) the `workflows/scripts/` directory next to the agent dir for a
+   `<name>-wf_<id>.js` file; fall back to the id.
+3. Main-session records (no `_workflowId`) are untouched.
+
+**Acceptance:** a quick `node -e` harness against the real
+`d--Jiaming-PolyU-research` data shows ≥2 workflows for 2026-06-02, with 32
+agents / ~24.6M tokens total across them (tolerance: exact numbers may drift
+as logs age out).
+
+### Phase 2 — Workflows tab (webview)
+
+New tab "Workflows" after "Branches" (`I18n` keys for all six languages —
+en "Workflows", zh-CN "工作流", zh-TW "工作流", ja "ワークフロー",
+ko "워크플로", de "Workflows").
+
+Layout per the project's minimal style (reuse `.daily-table sortable-table`
+and the collapsible `<details>` pattern from Model Usage):
+
+- One row per workflow: start time · name · project · **agent count** ·
+  cost · input / output / cache-write / cache-read · **cache hit rate** ·
+  duration. Sortable columns via the existing `data-sort-*` mechanism.
+- Row expands (`<details>` or the project-group toggle pattern) to a
+  per-agent sub-table: agent id (short), cost, tokens, duration.
+- A one-line summary strip above the table: workflows this month · total
+  workflow cost · share of this month's total cost.
+- **Cache hit rate is the headline diagnostic**: per workflow, `cacheRead /
+  (input + cacheWrite + cacheRead)`. Render it with the existing summary
+  conventions. Rationale (documented in a hint line under the table):
+  native-Claude workflows reuse prompt cache across agents (high hit rate);
+  a provider with no cross-agent cache shows ~0% — i.e. the same workflow
+  costs disproportionately more. This is the "is my proxy well-adapted to
+  workflows" signal.
+
+**Acceptance:** tab renders with real data; expanding a workflow lists its
+agents; sorting works; no layout overflow at 800 px container width.
+
+### Phase 3 — Thinking share + quota guard
+
+1. **Thinking share column** (Sessions tab) and a line in the Today summary:
+   thinking tokens are already estimated by the content analyzer
+   (`catAssistantThinking`); expose a per-session share where the data
+   exists. Mark as estimate (reuse `estimatedNote` styling).
+2. **Effort hint:** if a session's thinking share > 60%, show an inline hint
+   ("Consider /effort high instead of xhigh for tasks like this") in the
+   Sessions row tooltip — *no popups*.
+3. **Quota guard (the high-value one):** when the dashboard renders and the
+   5h quota's remaining percentage is **below the average cost of the user's
+   last 3 workflow runs** (as % of the 5h window — derivable once Phase 1
+   lands by correlating workflow cost share against quota utilisation deltas;
+   if that's too indirect, fall back to a fixed configurable threshold
+   `claudeCodeUsage.workflowQuotaWarnPercent`, default 50), show a dismissible
+   warning banner in the dashboard: "A typical workflow run uses ~N% of your
+   5-hour window; you have M% left. Consider waiting for the reset —
+   interrupted runs lose their prompt cache and re-run ~40% more expensive."
+   Status bar stays untouched (no nagging).
+
+**Acceptance:** thinking column renders; banner appears when (and only when)
+remaining 5h % < threshold; banner is dismissible per window-session.
+
+### Phase 4 — Per-skill statistics (Content tab)
+
+In the content analyzer, detect skill invocations in assistant `tool_use`
+blocks named `Skill` (input contains the skill name) and в user-visible
+`<command-name>` markers. Tally per skill: invocation count + estimated
+tokens of the injected skill prompt (estimate from the text length of the
+matching tool result / command output, same `estimateTokens` heuristic).
+Render in the Content tab as a "Token by Skill" sub-table (name, count,
+est. tokens, share), marked as approximate. Purpose: identify low-value
+skills worth disabling — frame the hint line accordingly.
+
+**Acceptance:** superpowers / context7 / other installed skills appear with
+plausible counts on real data; zero-skill users see nothing (section hidden).
+
+### Phase 5 — AI advice upgrade
+
+Extend `buildAdviceSummary` with the new structured signals, each in a
+clearly labelled section: workflow runs (count, agent fan-out, cost share,
+cache hit rate per provider), thinking share, per-skill stats. Add an
+optional setting `claudeCodeUsage.advice.userContext` (string, default "") —
+free-text background the user writes about themself/the project (e.g.
+"non-programmer building a VS Code extension; expect heavy exploratory tool
+use"). When present, instruct the model to add a final section "Personalised
+for this project" that calibrates advice against that context instead of
+generic best practice. Keep the existing language enforcement.
+
+**Acceptance:** advice output contains workflow-aware observations and (when
+userContext is set) the personalised section; prompts sample still contains
+zero sub-agent content (Phase 0 invariant).
+
+## 4. Conventions and constraints (do not violate)
+
+- TypeScript strict; compile must be clean. Portable Node lives at
+  `D:\Jiaming\_tooling\node-v20.18.1-win-x64` (see `CLAUDE.local.md`).
+- All user-facing strings go through `I18n` with all six languages filled.
+- All-new settings default to today's behaviour (opt-in).
+- No new runtime dependencies.
+- The dashboard stays minimal: summaries first, detail on expand. When in
+  doubt, cut.
+- Respect commit hygiene: one meaningful commit per phase, squash-merge the
+  branch at the end.
+- `version` stays `2.1.0`; update `CHANGELOG.md` under `[2.1.0]` as phases
+  land; README feature list + zh-CN full translation updated once at the end.
+
+## 5. Verification data
+
+Real workflow data exists at
+`~/.claude/projects/d--Jiaming-PolyU-research/d5a3bdd7-7181-4b22-8145-187a1662cadc/`
+(2 workflows, 32 agents, mixed DeepSeek; produced 2026-06-02) — use it for
+manual verification alongside any synthetic fixtures you create.

--- a/docs/V2.2-AUTOMATION-SPEC.md
+++ b/docs/V2.2-AUTOMATION-SPEC.md
@@ -1,0 +1,179 @@
+# V2.2 Implementation Spec — Human-Gated AI Issue & PR Handling
+
+> **How to use this document:** like `V2.1-WORKFLOW-SPEC.md`, this is written
+> to be handed to a fresh Claude Code session (Fable 5, optionally with a
+> workflow) for end-to-end implementation: *"Implement
+> docs/V2.2-AUTOMATION-SPEC.md. Work phase by phase; stop after Phase 1 for a
+> checkpoint."* Prerequisite: v2.1.0 shipped; repo secrets managed by Jack.
+>
+> **Design principle (non-negotiable): a human (Carl) makes the final review
+> and authorization for anything that leaves the repo — every reply posted,
+> every commit pushed, every PR merged.** The AI prepares; the human ships.
+
+## 1. Goal
+
+`jack21/ClaudeCodeUsage` receives a steady trickle of issues and PRs. Most
+follow recognisable patterns (bug report with diagnostics, feature request,
+question answered by the README, small fix PR). v2.2 wires Claude into the
+GitHub repo so that:
+
+1. **New issues** are automatically triaged (labelled, deduplicated against
+   existing issues) and a **draft reply** is prepared — but *not posted* —
+   for Carl to approve.
+2. **New PRs** get an automatic first-pass review (correctness, conventions
+   from `CONTRIBUTING.md` / `CLAUDE.md`, i18n completeness) posted as a
+   normal review comment, clearly labelled as automated.
+3. **On-demand deep work** — fixing a bug an issue describes, drafting a
+   patch — is triggered explicitly by Carl mentioning `@claude` in a comment.
+
+## 2. Architecture overview
+
+Two complementary mechanisms, shipped as separate phases:
+
+### Mechanism A — mention-driven agent (`anthropics/claude-code-action`)
+
+The official GitHub Action. Installed once; triggers **only** when a
+maintainer mentions `@claude` in an issue/PR comment with an instruction
+("@claude reproduce this and propose a fix"). The action runs Claude Code in
+CI, can read the repo, and either replies in-thread or pushes a branch and
+opens a PR.
+
+- **Human gate:** nothing runs without an explicit maintainer mention, and
+  any code change arrives as a PR that Carl reviews and merges. Replies are
+  posted directly, but only ever as a result of Carl's explicit instruction.
+- **Restrict triggering** to maintainers: the action supports limiting to
+  users with write access — required, otherwise anyone could spend our API
+  budget by mentioning the bot.
+
+### Mechanism B — draft-queue triage (custom workflows, fully human-gated)
+
+For *automatic* processing of every new issue without auto-posting anything:
+
+```
+issue opened ──▶ [triage workflow]
+                  │  runs Claude (API) with: issue body + labels taxonomy +
+                  │  README/CHANGELOG/recent issues as context
+                  │
+                  ├─ applies labels (bug / enhancement / question / needs-info
+                  │  / possible-duplicate-of-#N)        ← low-risk, auto-applied
+                  │
+                  └─ writes a draft reply to
+                     .github/triage-drafts/issue-<N>.md
+                     and opens a "Triage: #<N>" PR with it
+                                  │
+            Carl reviews the draft PR (edits the text freely)
+                                  │
+                     merge = authorization ──▶ [post workflow]
+                                  │  posts the file body as a comment on #N,
+                                  │  applies any `close: true` front-matter,
+                                  │  deletes the draft file
+                                  │
+                     close PR unmerged = veto (nothing posted)
+```
+
+- **Human gate:** the *merge* of the triage PR is the explicit authorization.
+  Editing the draft before merging is the natural review step. Closing the
+  PR discards the draft. Nothing is ever posted without a merge.
+- Labels are applied automatically because they are cheap to revert and
+  carry no outward communication.
+
+## 3. Phases
+
+### Phase 1 — Mention-driven agent (small, ships first)
+
+1. Add `.github/workflows/claude.yml` using `anthropics/claude-code-action@v1`
+   (check the action's current README for exact inputs — it evolves):
+   - Trigger: `issue_comment`, `pull_request_review_comment` (created), filter
+     body contains `@claude`.
+   - Gate: job-level `if` that checks `comment.author_association` is
+     `OWNER`/`MEMBER`/`COLLABORATOR`.
+   - Auth: `ANTHROPIC_API_KEY` repo secret (Jack adds it; coordinate like
+     VSCE_PAT). The action also supports Claude subscription OAuth tokens —
+     decide with Jack which to use; API key is simpler for CI.
+   - `permissions`: `contents: write`, `pull-requests: write`,
+     `issues: write` — the minimum the action needs to reply and open PRs.
+   - Custom instructions input: point it at `CLAUDE.md` + `CONTRIBUTING.md`
+     conventions (compile must pass, i18n six languages, opt-in defaults).
+2. Document usage in `CONTRIBUTING.md` (one paragraph: maintainers can invoke
+   `@claude` for assisted fixes; outputs are reviewed like any contribution).
+
+**Acceptance:** Carl comments "@claude summarize this issue" on a test issue
+→ the action replies in-thread; a non-maintainer mention does nothing.
+
+### Phase 2 — Triage workflow (labels + draft queue)
+
+1. `.github/workflows/triage.yml`, trigger `issues: [opened]`:
+   - Calls the Claude API (a small script with `fetch`, model
+     `claude-haiku-4-5` for cost — triage is classification, not creation)
+     with: issue title/body, the label taxonomy, the last ~30 issue titles
+     (for duplicate detection), and condensed README/troubleshooting.
+   - Output contract (JSON): `{ labels: string[], duplicateOf?: number,
+     draftReply: string, close?: boolean }`.
+   - Applies labels via `gh issue edit`. Never closes anything.
+   - Writes `.github/triage-drafts/issue-<N>.md` with YAML front-matter
+     (`issue: N`, `close: false`) + the draft reply body; commits to branch
+     `triage/issue-<N>`; opens a PR titled `Triage: #<N> <title>`.
+2. `.github/workflows/triage-post.yml`, trigger `pull_request: [closed]` with
+   `if: merged == true && head branch starts with triage/`:
+   - Reads the merged draft file, posts its body as a comment on issue `<N>`
+     (`gh issue comment`), closes the issue if front-matter `close: true`,
+     then deletes the draft file in a follow-up commit (keep `triage-drafts/`
+     clean).
+3. Cost control: triage uses Haiku; cap input (truncate issue bodies at ~8 KB);
+   skip issues opened by maintainers (Carl/Jack don't need triage).
+4. Failure mode: if the model output doesn't parse as the JSON contract, the
+   workflow applies a `needs-human-triage` label and exits 0 (never crash-loop,
+   never guess).
+
+**Acceptance:** opening a test issue produces correct labels + a triage PR
+with a sensible draft within ~2 minutes; merging the PR posts the comment;
+closing it unmerged posts nothing.
+
+### Phase 3 — PR first-pass review
+
+`.github/workflows/pr-review.yml`, trigger `pull_request_target: [opened]`
+**with extreme care**: never check out or execute PR head code with secrets in
+scope. The review job:
+- Fetches the PR diff via the API (text only, no checkout of the head).
+- Sends diff + `CONTRIBUTING.md` checklist + `CLAUDE.md` conventions to
+  Claude (Sonnet-tier), asking for: correctness concerns, convention
+  violations (i18n completeness, missing CHANGELOG), and a merge-readiness
+  summary.
+- Posts one review comment, prefixed: `🤖 **Automated first-pass review**
+  (maintainer will follow up — replies here reach a human).`
+- Skip PRs authored by maintainers, and skip when the diff exceeds ~3000
+  lines (label `needs-human-review` instead).
+
+This one *does* auto-post — acceptable because a review comment is advisory,
+clearly machine-labelled, and pre-approved in shape by this spec. If that
+feels too forward, route it through the Phase-2 draft queue instead (same
+plumbing, `pr-<N>.md` drafts).
+
+**Acceptance:** a test PR receives a labelled automated review; a 5000-line
+PR gets only the label; maintainer PRs are untouched.
+
+## 4. Security & cost guardrails (apply to every phase)
+
+- Secrets (`ANTHROPIC_API_KEY`) are repo secrets; **forked-PR workflows must
+  not access them** — use `pull_request_target` only with no-checkout API
+  reads as in Phase 3, or restrict to same-repo events.
+- Job-level `permissions:` blocks list only what each workflow needs.
+- Every workflow has `concurrency` with `cancel-in-progress: true` keyed on
+  the issue/PR number (no pile-ups), and a `timeout-minutes: 10`.
+- Monthly budget: triage on Haiku ≈ negligible; mention-driven runs are
+  bounded by Carl's own invocations. Add a `MAX_TURNS`/turn-limit input on
+  the claude-code-action.
+- Kill switch: all workflows check a repo variable `AUTOMATION_ENABLED`
+  (`vars.AUTOMATION_ENABLED == 'true'`) so automation can be disabled from
+  Settings → Variables without touching code.
+
+## 5. Conventions
+
+- Workflows live in `.github/workflows/`; scripts they call live in
+  `.github/scripts/` (plain Node, no dependencies, runnable with `node`).
+- Every automated outward message is visibly labelled as automated and signs
+  off with "a maintainer reviews everything" phrasing — manage expectations,
+  keep the human relationship Carl has built with contributors.
+- Drafts and prompts in English; if the issue author wrote in Chinese, the
+  draft reply should be bilingual (mirror the project's bilingual style).
+- One commit per phase; squash-merge; CHANGELOG under `[2.2.0]` § Automation.

--- a/docs/V2.2-FEATURES-SPEC.md
+++ b/docs/V2.2-FEATURES-SPEC.md
@@ -1,0 +1,165 @@
+# V2.2 Implementation Spec — Visualization, Settings Panel & Behaviour Optimisation
+
+> Companion to `V2.2-AUTOMATION-SPEC.md` (AI issue/PR handling). This file
+> covers the *product* side of v2.2: new visualizations, a consolidated
+> settings panel, and behaviour-optimisation features. Same usage pattern:
+> hand to a fresh Fable 5 session — *"Implement docs/V2.2-FEATURES-SPEC.md,
+> phase by phase, stop after Phase A for a checkpoint."* Prereq: v2.1.0
+> (workflow attribution) shipped — several features below consume the
+> `WorkflowUsage` model and per-skill stats it introduces.
+>
+> **Guiding constraint (repeat after me): the project is *lightweight and
+> efficient*.** Every feature here must earn its place; default to off or to
+> a collapsed/secondary view; never crowd the primary surfaces. If a feature
+> can be a column instead of a tab, make it a column.
+
+## Phase A — Settings consolidation (do this FIRST; everything else adds settings)
+
+**Problem:** 18+ flat `claudeCodeUsage.*` settings clutter the VS Code
+Settings UI. Adding more (this spec adds several) makes it worse.
+
+**Approach:**
+1. Keep the VS Code `contributes.configuration` entries (some users edit
+   settings.json directly, and VS Code sync needs them) but **group them** with
+   dotted sub-namespaces so the Settings UI nests them:
+   `display.*` (language, decimalPlaces, compactNumbers, timezone),
+   `refresh.*` (interval, fileWatching, pauseDashboardRefresh),
+   `quota.*` (tracking, warnThreshold…), `advice.*` (already grouped),
+   `analysis.*` (enableContentAnalysis, projectGroupingMode). Migrate old keys
+   with backward-compatible reads (pattern already used for `advice.apiKey`).
+2. Add a **Settings panel inside the dashboard** — a gear/"⚙ Settings" tab
+   that renders the grouped options as a compact form (checkboxes, selects,
+   number inputs), writing through `vscode.workspace.getConfiguration().update`
+   (same channel the auto-refresh toggle already uses). This is the
+   user-facing "don't make me hunt in VS Code settings" surface.
+3. The dashboard form and the VS Code settings stay in sync (both read/write
+   the same config keys).
+
+**Acceptance:** all existing settings reachable from the dashboard panel;
+changing one there persists and reflects in VS Code settings and vice versa;
+old flat keys still honoured.
+
+## Phase B — Pre-emptive quota warning + optional auto-continue
+
+Two related behaviours around the 5-hour window. **High value** — this is the
+"I hate hitting the limit mid-task" pain.
+
+### B1. Pre-emptive warning (default on, threshold configurable)
+- New setting `claudeCodeUsage.quota.warnThreshold` (default **60**; the
+  observed cost of one max-effort ultracode run is ~50–60% of a 5h window).
+- When a dashboard refresh sees 5h utilisation cross the threshold **upward**,
+  show a single VS Code notification: "You're at N% of your 5-hour quota. A
+  full ultracode run typically uses ~M% — consider finishing current work
+  before the reset to avoid a mid-run pause." Debounce: at most once per 5h
+  window (track the window's `resets_at`); dismissible.
+- Pure status-bar colour already warns ≥80%/≥95%; this adds the actionable
+  *predictive* nudge earlier.
+
+### B2. Optional auto-continue (default OFF, clearly experimental)
+- Inspiration: [AutoContinue](https://github.com/CrisChenYingyan/AutoContinue)
+  — avoids losing a long task when the 5h window resets mid-run, and avoids
+  the ~40% re-cost of resuming after a pause (lost prompt cache).
+- **Important scoping:** this extension is read-only over the logs and must
+  *stay* read-only over Claude Code's data. Auto-continue means *sending input
+  to Claude Code*, which is a different trust level. Implement as: an opt-in
+  `claudeCodeUsage.experimental.autoContinue` setting that, when the 5h window
+  resets while a session was paused at the limit, surfaces a **one-click
+  "Resume now"** action (a notification button) rather than silently typing
+  into the terminal. Investigate whether Claude Code exposes a resume command
+  the extension can invoke via `vscode.commands.executeCommand`; if not, the
+  one-click action copies the resume command to the clipboard / shows it.
+  Do **not** automate keystrokes into a terminal — too fragile and surprising.
+- Document the trade-off plainly in the README.
+
+**Acceptance:** warning fires once per window above threshold; auto-continue is
+off by default; when on, the resume affordance appears only at a real reset.
+
+## Phase C — Behaviour-optimisation analytics
+
+### C1. Skill ROI view (Content tab; consumes v2.1 per-skill stats)
+"You have 8 skills installed; this month you used 3. The other 5 cost ~X
+tokens/turn in loaded context." Cross-reference installed skills
+(`~/.claude/.claude.json` → `skillUsage`/`pluginUsage`, and the
+`.claude/skills` / plugin dirs) against observed invocations. Render a
+"Skill ROI" sub-section: skill · installed? · invocations (30d) · est.
+tokens · a "rarely used — consider disabling" flag. Actionable framing:
+disabling a low-value skill beats adding a new one.
+
+### C2. Cost prediction
+Dashboard card: "If you run another ultracode workflow now, est. cost ≈ $X
+(based on your last 10 runs)." Compute from `WorkflowUsage` history: mean +
+spread of recent workflow costs; show range, not false precision. Also a
+simpler "this session is trending toward ~$Y by end of day" from today's
+slope. Keep it one small card, clearly labelled estimate.
+
+### C3. Cumulative usage line chart
+A cumulative (running-total) cost line over the selected period, in addition
+to the per-day bars — makes "how fast am I burning" legible. Reuse the gridded
+chart infra; a line is a polyline over the same x-axis. Add as a toggle on the
+existing daily/monthly chart (bars ↔ cumulative line), not a new tab.
+
+### C4. Duration / efficiency stats
+Per model (and optionally per task type): tokens-per-active-minute, output
+share, and a rough "efficiency" read (output tokens ÷ cost). Goal: see which
+model/settings get more done per unit time/cost during autonomous runs.
+Derive duration from session/workflow start–end timestamps. Surface in the
+Sessions/Workflows tabs as columns, plus a small per-model summary. Mark
+efficiency as heuristic.
+
+### C5. Model recommendation (the important one)
+**Goal:** "For this task's difficulty/output profile, an equivalent run on
+<model X> with <thinking/effort Y> would cost ≈ $Z (−W% / +W%). Suggested
+setup: …" Approach:
+1. From a session/workflow, extract a difficulty/output fingerprint: total
+   output tokens, thinking share, tool-call count, peak context, cache hit
+   rate, number of turns.
+2. Re-price the *same token profile* under other models' rates (the pricing
+   table already has Fable 5 / Opus / Sonnet / Haiku / DeepSeek etc.) — this
+   is a deterministic "what would the same tokens have cost elsewhere"
+   calculation, presented as an estimate (different models tokenise/▒think
+   differently, so caveat clearly — esp. the Opus 4.7+ tokenizer using up to
+   ~35% more tokens).
+3. Heuristic suggestion layer: if thinking share is low and the task hit cache
+   well, a cheaper tier likely suffices → recommend it with the projected
+   saving. If output was large and thinking high, recommend keeping the
+   frontier model but maybe lower effort. This is where the AI-advice feature
+   (v2.1 Phase 5) can do the nuanced reasoning — feed it the fingerprint +
+   the re-priced table and let it recommend.
+4. Surface: a "Model fit" line per session/workflow + an overall
+   "this month you'd have saved ≈ $N using <model> for the <category> tasks"
+   summary. **This is the headline differentiator** — no other tool does
+   retrospective model-fit costing.
+
+### C6. One-page export / share
+A "Export overview" action that renders the current dashboard summary (today /
+month / all-time totals, top models, top projects, cost composition, quota
+snapshot) to a single self-contained file: Markdown by default, optionally an
+HTML/PNG one-pager. No external upload — write to a file the user chooses
+(`vscode.window.showSaveDialog`). Strip/abbreviate project paths for
+shareability.
+
+## Phase D — Rendering fixes carried in alongside
+
+- **Dark-mode cache-miss bar invisible** (reported): in dark themes the
+  "Input Cache (Miss)" bar shows the number but no bar. Investigate the
+  `.cache-creation-bar` / `seg-cache-creation` colours (`--vscode-charts-purple`
+  / pink gradients can collapse to near-background on some dark themes).
+  Likely fix: give bars a min-contrast fallback colour and a subtle 1px border
+  so they're always visible regardless of theme. Verify across the default
+  Dark+, Dark Modern, and a high-contrast dark theme. (If a quick, certain fix
+  surfaces during v2.0.x it can ship earlier — but it needs the reporter's
+  theme name to repro.)
+
+## Conventions (same as every phase doc)
+
+TypeScript strict, clean compile; all strings via I18n × six languages; new
+settings default to today's behaviour; no new runtime deps; minimal UI —
+secondary/collapsed by default; one commit per phase; squash-merge; CHANGELOG
+`[2.2.0]`; README + zh-CN updated once at the end.
+
+## Real verification data
+
+`~/.claude/projects/` on the maintainer's machine (multiple projects, native
+Claude + DeepSeek via CC Switch, real ultracode/workflow runs incl.
+`d--Jiaming-PolyU-research/…/d5a3bdd7-…`). `~/.claude.json` has `skillUsage`
+and `pluginUsage` for Phase C1.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-code-usage",
   "displayName": "Claude Code Usage",
   "description": "Monitor Claude Code usage and costs in VSCode status bar",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "publisher": "GrowthJack",
   "author": "GrowthJack",
   "license": "MIT",

--- a/src/claudeApiClient.ts
+++ b/src/claudeApiClient.ts
@@ -105,9 +105,19 @@ export class ClaudeApiClient {
       return null;
     }
     if (this.isTokenExpired(credentials)) {
+      // Claude Code refreshes ~/.claude/.credentials.json itself. Re-read from
+      // disk FIRST — it has very likely already rotated the token — before
+      // attempting our own refresh. Without this, a cached-in-memory expired
+      // token would stick until the extension host restarts, which is exactly
+      // why "quota only comes back after I restart VS Code" was happening.
+      const fresh = await this.loadCredentials();
+      if (fresh && !this.isTokenExpired(fresh)) {
+        this.log('token: expired in memory, re-read a fresh one from disk');
+        return fresh;
+      }
       this.log('token: expired, refreshing');
       try {
-        credentials = await this.refreshAccessToken(credentials);
+        credentials = await this.refreshAccessToken(fresh || credentials);
       } catch (e) {
         this.log(`token: refresh failed: ${(e as Error).message}`);
         return null;
@@ -235,8 +245,12 @@ export class ClaudeApiClient {
       let response = await this.callUsageApi(credentials.claudeAiOauth.accessToken);
 
       if (response.status === 429) {
-        this.rateLimitedUntil = Date.now() + 5 * 60 * 1000;
-        this.log('429: rate-limited, cooling down 5 min');
+        // 60 s cool-down. The old flat 5-minute cool-down made a single 429
+        // look like the indicator had broken (only a restart appeared to fix
+        // it). Paired with the gentler fetch cadence below, 429s should be
+        // rare and short-lived.
+        this.rateLimitedUntil = Date.now() + 60 * 1000;
+        this.log('429: rate-limited, cooling down 60s');
         return null;
       }
 

--- a/src/dataLoader.ts
+++ b/src/dataLoader.ts
@@ -648,33 +648,62 @@ export class ClaudeDataLoader {
     return data;
   }
 
-  static getCurrentSessionData(records: ClaudeUsageRecord[]): SessionData | null {
+  /**
+   * The "current session" shown next to today's cost in the status bar — the
+   * single most-recently-active conversation (one `.jsonl` / `_sessionId`),
+   * scoped to the current workspace when one is given.
+   *
+   * Previously this aggregated *all* records from the last 5 hours across every
+   * project, so every VS Code window showed the same number regardless of which
+   * workspace it was. Now each window reflects its own workspace's current
+   * conversation. Returns null if there's been no activity in the last 5 hours
+   * (so a stale session doesn't masquerade as "current").
+   *
+   * @param workspacePath optional current workspace folder; records whose cwd
+   *   sits under it are preferred. Falls back to all records if the workspace
+   *   has no matching records (e.g. a brand-new folder).
+   */
+  static getCurrentSessionData(records: ClaudeUsageRecord[], workspacePath?: string): SessionData | null {
     if (records.length === 0) {
       return null;
     }
+    const norm = (p: string): string => (p || '').replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
 
-    // Sort records by timestamp
-    const sortedRecords = records.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+    let pool = records;
+    if (workspacePath) {
+      const wp = norm(workspacePath);
+      const scoped = records.filter((r) => norm(r._projectPath || '').startsWith(wp));
+      if (scoped.length > 0) {
+        pool = scoped;
+      }
+    }
 
-    const now = new Date();
-    const sessionRecords = sortedRecords.filter((record) => {
-      const recordTime = new Date(record.timestamp);
-      const timeDiff = now.getTime() - recordTime.getTime();
-      return timeDiff <= 5 * 60 * 60 * 1000; // 5 hours in milliseconds
-    });
+    // The most recent record identifies the current session.
+    let latest = pool[0];
+    for (const r of pool) {
+      if (new Date(r.timestamp).getTime() > new Date(latest.timestamp).getTime()) {
+        latest = r;
+      }
+    }
 
+    // Recency guard: if the latest activity is older than the 5-hour window,
+    // there is no "current" session to show.
+    if (Date.now() - new Date(latest.timestamp).getTime() > 5 * 60 * 60 * 1000) {
+      return null;
+    }
+
+    const sessionId = latest._sessionId;
+    const sessionRecords = pool.filter((r) => r._sessionId === sessionId);
     if (sessionRecords.length === 0) {
       return null;
     }
 
     const usageData = this.calculateUsageData(sessionRecords);
-    const sessionStart = new Date(sessionRecords[0].timestamp);
-    const sessionEnd = new Date(sessionRecords[sessionRecords.length - 1].timestamp);
-
+    const times = sessionRecords.map((r) => new Date(r.timestamp).getTime());
     return {
       ...usageData,
-      sessionStart,
-      sessionEnd,
+      sessionStart: new Date(Math.min(...times)),
+      sessionEnd: new Date(Math.max(...times)),
     };
   }
 

--- a/src/dataLoader.ts
+++ b/src/dataLoader.ts
@@ -348,8 +348,11 @@ export class ClaudeDataLoader {
       // record has the higher total token sum (issue #18).
       const processedHashes = new Map<string, number>();
       const records: ClaudeUsageRecord[] = [];
-      // sessionId → conversation title, harvested from `summary` log lines.
-      const titleBySession: Record<string, string> = {};
+      // sessionId → conversation title. Current Claude Code writes
+      // `custom-title` (user-set) and `ai-title` (auto) lines; older versions
+      // wrote `summary`. A custom title always wins over an AI one.
+      const aiTitleBySession: Record<string, string> = {};
+      const customTitleBySession: Record<string, string> = {};
       // Content analysis (last 30 days) is optional — skipped when the user
       // disables it via claudeCodeUsage.enableContentAnalysis.
       const analysis = analyzeContent ? newAnalysisAcc(Date.now() - 30 * 24 * 60 * 60 * 1000) : null;
@@ -364,6 +367,7 @@ export class ClaudeDataLoader {
         replacedByDedup: 0,
         skippedByDedup: 0,
         kept: 0,
+        userPrompts: 0,
         // model name → { count, totalTokens }. totalTokens lets us tell whether
         // records exist but are all zeros (proxy-placeholder only).
         models: {} as Record<string, { count: number; tokens: number }>,
@@ -379,6 +383,10 @@ export class ClaudeDataLoader {
 
           // Each .jsonl file is one Claude Code conversation/session.
           const sessionInfo = this.parseSessionInfo(file);
+          // Sub-agent / workflow logs: count their usage, but never harvest
+          // user prompts from them (their "user" lines are agent-framework
+          // task dispatches, not something the user typed).
+          const isSubagentFile = /[\\/]subagents[\\/]/.test(file);
 
           for (const line of lines) {
             stats.linesScanned += 1;
@@ -390,12 +398,60 @@ export class ClaudeDataLoader {
                 analyzeLine(parsed, analysis);
               }
 
-              // Conversation title: Claude Code writes a summary line per
-              // session — the same title `claude --resume` shows. Keep the
-              // last one seen (titles get refreshed as the chat evolves).
-              const maybeSummary = parsed as { type?: unknown; summary?: unknown };
-              if (maybeSummary.type === 'summary' && typeof maybeSummary.summary === 'string') {
-                titleBySession[sessionInfo.sessionId] = maybeSummary.summary;
+              // Conversation title lines. Keep the last seen of each kind —
+              // titles get refreshed as the chat evolves.
+              const lineAny = parsed as Record<string, unknown>;
+              if (lineAny.type === 'ai-title' && typeof lineAny.aiTitle === 'string') {
+                aiTitleBySession[sessionInfo.sessionId] = lineAny.aiTitle;
+              } else if (lineAny.type === 'custom-title' && typeof lineAny.customTitle === 'string') {
+                customTitleBySession[sessionInfo.sessionId] = lineAny.customTitle;
+              } else if (lineAny.type === 'summary' && typeof lineAny.summary === 'string') {
+                // Legacy location (older Claude Code versions).
+                aiTitleBySession[sessionInfo.sessionId] = lineAny.summary;
+              }
+
+              // Genuine user prompts become synthetic zero-usage records so
+              // "Messages" counts what the user actually typed (not API
+              // calls). Excludes meta lines (command output), sidechain
+              // dispatches and anything inside sub-agent logs.
+              if (
+                !isSubagentFile &&
+                (lineAny.type === 'user' || (lineAny.message as { role?: unknown } | undefined)?.role === 'user') &&
+                !lineAny.isMeta &&
+                !lineAny.isSidechain &&
+                typeof lineAny.timestamp === 'string'
+              ) {
+                const content = (lineAny.message as { content?: unknown } | undefined)?.content;
+                const hasText =
+                  typeof content === 'string'
+                    ? content.trim().length > 0
+                    : Array.isArray(content) &&
+                      content.some(
+                        (b: { type?: unknown; text?: unknown }) =>
+                          b?.type === 'text' && typeof b.text === 'string' && b.text.trim().length > 0
+                      );
+                if (hasText) {
+                  const prompt: ClaudeUsageRecord = {
+                    timestamp: lineAny.timestamp,
+                    message: { usage: { input_tokens: 0, output_tokens: 0 } },
+                    _isUserPrompt: true,
+                    _sessionId: sessionInfo.sessionId,
+                    _projectDirEncoded: sessionInfo.projectPath,
+                  };
+                  const pcwd = lineAny.cwd;
+                  if (typeof pcwd === 'string' && pcwd.trim() !== '') {
+                    prompt._projectPath = pcwd;
+                    prompt._projectName = this.lastPathSegment(pcwd);
+                  } else {
+                    prompt._projectPath = sessionInfo.projectPath;
+                    prompt._projectName = sessionInfo.projectName;
+                  }
+                  const pBranch = lineAny.gitBranch;
+                  prompt._gitBranch = typeof pBranch === 'string' && pBranch.trim() !== '' ? pBranch : undefined;
+                  records.push(prompt);
+                  stats.userPrompts += 1;
+                  continue;
+                }
               }
 
               if (!validateUsageRecord(parsed)) {
@@ -412,6 +468,7 @@ export class ClaudeDataLoader {
               // over the lossy, dash-encoded folder name when it is available.
               const record = data as ClaudeUsageRecord;
               record._sessionId = sessionInfo.sessionId;
+              record._projectDirEncoded = sessionInfo.projectPath;
               const cwd = (parsed as { cwd?: unknown }).cwd;
               if (typeof cwd === 'string' && cwd.trim() !== '') {
                 record._projectPath = cwd;
@@ -465,11 +522,14 @@ export class ClaudeDataLoader {
         }
       }
 
-      // Attach harvested conversation titles. A post-pass because a session's
-      // summary line and its usage records can sit in different files
-      // (sub-agent logs share the parent session's id but carry no summary).
+      // Attach harvested conversation titles (custom beats AI). A post-pass
+      // because a session's title lines and its usage records can sit in
+      // different files (sub-agent logs share the parent session's id).
       for (const record of records) {
-        const title = record._sessionId ? titleBySession[record._sessionId] : undefined;
+        if (!record._sessionId) {
+          continue;
+        }
+        const title = customTitleBySession[record._sessionId] || aiTitleBySession[record._sessionId];
         if (title) {
           record._sessionTitle = title;
         }
@@ -494,7 +554,8 @@ export class ClaudeDataLoader {
           .join(', ') || 'none';
         log(
           `loader: ${stats.files} files, ${stats.linesScanned} lines | ` +
-            `kept=${stats.kept}, dedup-replaced=${stats.replacedByDedup}, ` +
+            `kept=${stats.kept}, user-prompts=${stats.userPrompts}, ` +
+            `dedup-replaced=${stats.replacedByDedup}, ` +
             `dedup-skipped=${stats.skippedByDedup}, parse-errors=${stats.parseErrors} | ` +
             `rejected: ${rejectedSummary}`
         );
@@ -630,6 +691,12 @@ export class ClaudeDataLoader {
     };
 
     for (const record of records) {
+      // Synthetic user-prompt markers: count towards Messages and nothing else.
+      // "Messages" therefore means messages the user typed, not API calls.
+      if (record._isUserPrompt) {
+        data.messageCount++;
+        continue;
+      }
       // Only count records with usage and model (typically assistant type)
       if (!record.message.usage || !record.message.model) {
         continue;
@@ -662,7 +729,8 @@ export class ClaudeDataLoader {
       data.costBreakdown.output += costParts.output;
       data.costBreakdown.cacheWrite += costParts.cacheWrite;
       data.costBreakdown.cacheRead += costParts.cacheRead;
-      data.messageCount++;
+      // messageCount intentionally NOT incremented here — it counts the
+      // synthetic user-prompt markers above, i.e. messages the user typed.
 
       if (!data.modelBreakdown[model]) {
         data.modelBreakdown[model] = {
@@ -702,12 +770,19 @@ export class ClaudeDataLoader {
    *   sits under it are preferred. Falls back to all records if the workspace
    *   has no matching records (e.g. a brand-new folder).
    */
-  /** Records belonging to the given workspace folder. Two ways to match:
-   *  1. The record's `cwd` (preferred `_projectPath`) sits under the folder.
-   *  2. The record only has the dash-encoded project directory name (records
-   *     without a `cwd` field fall back to it) and that encoding matches the
-   *     workspace folder encoded the same way Claude Code does
-   *     (`D:\Jiaming\My_Proj` → `d--Jiaming-My-Proj`).
+  /** Records belonging to the given workspace folder.
+   *
+   * Primary match: the session's home project directory (`_projectDirEncoded`,
+   * derived from where the .jsonl lives = where the session was started)
+   * equals the workspace folder encoded the same way Claude Code does
+   * (`D:\Jiaming\My_Proj` → `d--Jiaming-My-Proj`). This attributes the WHOLE
+   * conversation to its workspace even though per-record `cwd` wanders as
+   * work moves between folders mid-session (observed: one session split
+   * 10/71 across two cwds, fragmenting the per-project figure).
+   *
+   * Secondary match: the record's cwd sits under the folder — catches
+   * sessions started elsewhere that did work inside this workspace.
+   *
    * Returns all records when no workspace is given. */
   static filterByWorkspace(records: ClaudeUsageRecord[], workspacePath?: string): ClaudeUsageRecord[] {
     if (!workspacePath) {
@@ -717,6 +792,9 @@ export class ClaudeDataLoader {
     const wp = norm(workspacePath);
     const encoded = workspacePath.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
     return records.filter((r) => {
+      if ((r._projectDirEncoded || '').toLowerCase() === encoded) {
+        return true;
+      }
       const p = norm(r._projectPath || '');
       return p.startsWith(wp) || p === encoded;
     });
@@ -866,7 +944,9 @@ export class ClaudeDataLoader {
     });
 
     return sessions
-      .filter((s) => s.data.messageCount > 0)
+      // messageCount now means user-typed prompts; keep sessions that have
+      // real spend even if no prompt landed in the window (e.g. continuations).
+      .filter((s) => s.data.messageCount > 0 || s.data.totalCost > 0)
       .sort((a, b) => b.endTime.getTime() - a.endTime.getTime())
       .slice(0, limit);
   }

--- a/src/dataLoader.ts
+++ b/src/dataLoader.ts
@@ -422,15 +422,16 @@ export class ClaudeDataLoader {
                 typeof lineAny.timestamp === 'string'
               ) {
                 const content = (lineAny.message as { content?: unknown } | undefined)?.content;
-                const hasText =
+                const text =
                   typeof content === 'string'
-                    ? content.trim().length > 0
-                    : Array.isArray(content) &&
-                      content.some(
-                        (b: { type?: unknown; text?: unknown }) =>
-                          b?.type === 'text' && typeof b.text === 'string' && b.text.trim().length > 0
-                      );
-                if (hasText) {
+                    ? content
+                    : Array.isArray(content)
+                      ? content
+                          .filter((b: { type?: unknown; text?: unknown }) => b?.type === 'text' && typeof b.text === 'string')
+                          .map((b: { text: string }) => b.text)
+                          .join('')
+                      : '';
+                if (text.trim().length > 0 && !this.isSyntheticUserText(text)) {
                   const prompt: ClaudeUsageRecord = {
                     timestamp: lineAny.timestamp,
                     message: { usage: { input_tokens: 0, output_tokens: 0 } },
@@ -619,6 +620,28 @@ export class ClaudeDataLoader {
     const segments = projectPath.split('-').filter((s) => s.length > 0);
     const projectName = segments.length > 0 ? segments[segments.length - 1] : projectPath || 'unknown';
     return { sessionId, projectName, projectPath };
+  }
+
+  /** True if a `user` line's text is a Claude Code system marker rather than
+   * something the user actually typed: an interruption notice, or the echo of
+   * a slash command (`/model`, `/clear`, …) and its output. These otherwise
+   * inflate the "Messages" count (one session showed 106 vs ~80 real prompts:
+   * `[Request interrupted by user]` ×3, `<command-name>/model…` ×8, etc.). */
+  private static isSyntheticUserText(text: string): boolean {
+    const t = text.trim();
+    if (/^\[Request interrupted/i.test(t)) {
+      return true;
+    }
+    // Slash-command echo blocks wrap the invocation/output in these tags.
+    if (
+      t.startsWith('<command-name>') ||
+      t.startsWith('<command-message>') ||
+      t.includes('<local-command-stdout>') ||
+      t.includes('<local-command-caveat>')
+    ) {
+      return true;
+    }
+    return false;
   }
 
   /** Last segment of a path, handling both '/' and '\\' separators. */

--- a/src/dataLoader.ts
+++ b/src/dataLoader.ts
@@ -348,6 +348,8 @@ export class ClaudeDataLoader {
       // record has the higher total token sum (issue #18).
       const processedHashes = new Map<string, number>();
       const records: ClaudeUsageRecord[] = [];
+      // sessionId → conversation title, harvested from `summary` log lines.
+      const titleBySession: Record<string, string> = {};
       // Content analysis (last 30 days) is optional — skipped when the user
       // disables it via claudeCodeUsage.enableContentAnalysis.
       const analysis = analyzeContent ? newAnalysisAcc(Date.now() - 30 * 24 * 60 * 60 * 1000) : null;
@@ -386,6 +388,14 @@ export class ClaudeDataLoader {
               // Feed every line into the content analysis (not only usage records).
               if (analysis) {
                 analyzeLine(parsed, analysis);
+              }
+
+              // Conversation title: Claude Code writes a summary line per
+              // session — the same title `claude --resume` shows. Keep the
+              // last one seen (titles get refreshed as the chat evolves).
+              const maybeSummary = parsed as { type?: unknown; summary?: unknown };
+              if (maybeSummary.type === 'summary' && typeof maybeSummary.summary === 'string') {
+                titleBySession[sessionInfo.sessionId] = maybeSummary.summary;
               }
 
               if (!validateUsageRecord(parsed)) {
@@ -455,6 +465,16 @@ export class ClaudeDataLoader {
         }
       }
 
+      // Attach harvested conversation titles. A post-pass because a session's
+      // summary line and its usage records can sit in different files
+      // (sub-agent logs share the parent session's id but carry no summary).
+      for (const record of records) {
+        const title = record._sessionId ? titleBySession[record._sessionId] : undefined;
+        if (title) {
+          record._sessionTitle = title;
+        }
+      }
+
       if (log) {
         const rejectedSummary = Object.entries(stats.rejected)
           .map(([reason, count]) => `${reason}=${count}`)
@@ -513,8 +533,27 @@ export class ClaudeDataLoader {
    * The encoded-cwd folder is the working directory with path separators replaced by '-'.
    */
   private static parseSessionInfo(filePath: string): { sessionId: string; projectName: string; projectPath: string } {
-    const sessionId = path.basename(filePath, '.jsonl');
-    const projectPath = path.basename(path.dirname(filePath));
+    // Layouts under ~/.claude/projects/:
+    //   <proj-encoded>/<session-id>.jsonl                                 (main conversation)
+    //   <proj-encoded>/<session-id>/subagents/workflows/<wf>/agent-*.jsonl (workflow sub-agents)
+    // Walk up from the 'projects' directory so sub-agent files resolve to
+    // their parent session and real project — the old basename-only logic
+    // attributed them to a 'wf_xxx' pseudo-project with an 'agent-xxx'
+    // session id, fragmenting Sessions/Projects aggregation.
+    const parts = filePath.split(/[\\/]/);
+    const projIdx = parts.lastIndexOf(CLAUDE_PROJECTS_DIR_NAME);
+    let projectPath: string;
+    let sessionId = path.basename(filePath, '.jsonl');
+    if (projIdx >= 0 && projIdx + 1 < parts.length - 1) {
+      projectPath = parts[projIdx + 1];
+      if (projIdx + 2 < parts.length - 1) {
+        // File is nested below a session directory: the session is that
+        // directory's name, not the (agent-xxx / journal) file name.
+        sessionId = parts[projIdx + 2];
+      }
+    } else {
+      projectPath = path.basename(path.dirname(filePath));
+    }
     // Use the last meaningful segment of the encoded path as a friendly project name.
     const segments = projectPath.split('-').filter((s) => s.length > 0);
     const projectName = segments.length > 0 ? segments[segments.length - 1] : projectPath || 'unknown';
@@ -663,7 +702,12 @@ export class ClaudeDataLoader {
    *   sits under it are preferred. Falls back to all records if the workspace
    *   has no matching records (e.g. a brand-new folder).
    */
-  /** Records whose working directory sits under the given workspace folder.
+  /** Records belonging to the given workspace folder. Two ways to match:
+   *  1. The record's `cwd` (preferred `_projectPath`) sits under the folder.
+   *  2. The record only has the dash-encoded project directory name (records
+   *     without a `cwd` field fall back to it) and that encoding matches the
+   *     workspace folder encoded the same way Claude Code does
+   *     (`D:\Jiaming\My_Proj` → `d--Jiaming-My-Proj`).
    * Returns all records when no workspace is given. */
   static filterByWorkspace(records: ClaudeUsageRecord[], workspacePath?: string): ClaudeUsageRecord[] {
     if (!workspacePath) {
@@ -671,19 +715,21 @@ export class ClaudeDataLoader {
     }
     const norm = (p: string): string => (p || '').replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
     const wp = norm(workspacePath);
-    return records.filter((r) => norm(r._projectPath || '').startsWith(wp));
+    const encoded = workspacePath.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
+    return records.filter((r) => {
+      const p = norm(r._projectPath || '');
+      return p.startsWith(wp) || p === encoded;
+    });
   }
 
   static getCurrentSessionData(records: ClaudeUsageRecord[], workspacePath?: string): SessionData | null {
     if (records.length === 0) {
       return null;
     }
-    const norm = (p: string): string => (p || '').replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
 
     let pool = records;
     if (workspacePath) {
-      const wp = norm(workspacePath);
-      const scoped = records.filter((r) => norm(r._projectPath || '').startsWith(wp));
+      const scoped = this.filterByWorkspace(records, workspacePath);
       if (scoped.length > 0) {
         pool = scoped;
       }
@@ -805,8 +851,11 @@ export class ClaudeDataLoader {
       const first = sessionRecords[0];
       const peakContextTokens = sessionRecords.reduce((peak, r) => Math.max(peak, this.recordContextTokens(r)), 0);
 
+      const title = sessionRecords.find((r) => r._sessionTitle)?._sessionTitle;
+
       return {
         sessionId,
+        title,
         projectName: first._projectName || 'unknown',
         projectPath: first._projectPath || '',
         startTime,

--- a/src/dataLoader.ts
+++ b/src/dataLoader.ts
@@ -663,6 +663,17 @@ export class ClaudeDataLoader {
    *   sits under it are preferred. Falls back to all records if the workspace
    *   has no matching records (e.g. a brand-new folder).
    */
+  /** Records whose working directory sits under the given workspace folder.
+   * Returns all records when no workspace is given. */
+  static filterByWorkspace(records: ClaudeUsageRecord[], workspacePath?: string): ClaudeUsageRecord[] {
+    if (!workspacePath) {
+      return records;
+    }
+    const norm = (p: string): string => (p || '').replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+    const wp = norm(workspacePath);
+    return records.filter((r) => norm(r._projectPath || '').startsWith(wp));
+  }
+
   static getCurrentSessionData(records: ClaudeUsageRecord[], workspacePath?: string): SessionData | null {
     if (records.length === 0) {
       return null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,14 @@ export class ClaudeCodeUsageExtension {
   // file watcher can both fire while a slow reload is still in flight. Without
   // this, reloads pile up and keep re-asserting the "Loading…" spinner.
   private isRefreshing: boolean = false;
+  // Coalesce: a trigger that arrives mid-load sets this so we run exactly one
+  // more refresh after the current one finishes, instead of dropping the event
+  // (which starved updates during rapid ultracode/sub-agent writes).
+  private pendingRefresh: boolean = false;
+  // Epoch ms of the last observed .jsonl change. Drives activity-aware
+  // refresh cadence: while Claude Code is actively writing we refresh faster
+  // (~15 s, quota cache 20 s); when idle we fall back to the user's interval.
+  private lastActivityAt: number = 0;
 
   constructor(private context: vscode.ExtensionContext) {
     console.log('Claude Code Usage Extension: Constructor called');
@@ -349,6 +357,10 @@ export class ClaudeCodeUsageExtension {
         if (!filename || !String(filename).endsWith('.jsonl')) {
           return;
         }
+        // Mark activity so the polling timer and quota cache switch to the
+        // faster "active" cadence. This fires for sub-agent / workflow files
+        // too, since fs.watch is recursive.
+        this.lastActivityAt = Date.now();
         // Debounce: Claude Code writes lines in bursts and the file mtime
         // changes for every line.
         if (this.watchDebounceTimer) {
@@ -380,18 +392,31 @@ export class ClaudeCodeUsageExtension {
     this.watchedDir = null;
   }
 
+  /** True when Claude Code has written a log line in the last 60 s. */
+  private isActive(): boolean {
+    return Date.now() - this.lastActivityAt < 60000;
+  }
+
   private startAutoRefresh(): void {
-    // Clear existing timer
     if (this.refreshTimer) {
-      clearInterval(this.refreshTimer);
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = undefined;
     }
-
-    const config = this.getConfiguration();
-    const intervalMs = Math.max(config.refreshInterval * 1000, 30000); // Minimum 30 seconds
-
-    this.refreshTimer = setInterval(() => {
-      this.refreshData();
-    }, intervalMs);
+    // Self-rescheduling timer with an activity-aware interval: while Claude
+    // Code is actively writing logs we tick every ~15 s (matching the user's
+    // expectation that ultracode / high-consumption runs update promptly);
+    // when idle we use the user's configured interval (min 30 s). fs.watch
+    // already covers near-real-time status-bar cost updates during activity —
+    // this floor guarantees the quota also refreshes during sustained writes
+    // where the debounce never settles.
+    const tick = (): void => {
+      const base = Math.max(this.getConfiguration().refreshInterval * 1000, 30000);
+      const intervalMs = this.isActive() ? Math.min(base, 15000) : base;
+      this.refreshTimer = setTimeout(() => {
+        this.refreshData().finally(tick);
+      }, intervalMs);
+    };
+    tick();
   }
 
   /** Fetch real usage limits via OAuth, cached for 2 minutes. */
@@ -400,9 +425,12 @@ export class ClaudeCodeUsageExtension {
       return null;
     }
     const age = Date.now() - this.cache.usageLimitsLastUpdate.getTime();
-    // 120-second cache: matches the polling interval and avoids hammering
-    // /usage on every file-watch tick when active sessions write rapidly.
-    if (this.cache.usageLimits && age < 120000) {
+    // Activity-aware cache: 20 s while Claude Code is actively writing (so the
+    // quota keeps pace during high-consumption ultracode runs), 120 s when
+    // idle (avoids hammering /usage on every file-watch tick). The /usage
+    // client has its own 429 cool-down, so 20 s is safe.
+    const ttl = this.isActive() ? 20000 : 120000;
+    if (this.cache.usageLimits && age < ttl) {
       return this.cache.usageLimits;
     }
     const fetched = await this.apiClient.fetchUsageLimits();
@@ -417,6 +445,10 @@ export class ClaudeCodeUsageExtension {
 
   private async refreshData(manualTrigger: boolean = false): Promise<void> {
     if (this.isRefreshing) {
+      // Coalesce: remember that another refresh was requested and run exactly
+      // one more after the current finishes (see finally). Dropping the event
+      // outright starved updates during rapid ultracode / sub-agent writes.
+      this.pendingRefresh = true;
       return;
     }
     this.isRefreshing = true;
@@ -524,12 +556,20 @@ export class ClaudeCodeUsageExtension {
       }
     } finally {
       this.isRefreshing = false;
+      // If triggers arrived mid-load, run one more (background) refresh to pick
+      // up the changes they signalled. The pendingRefresh flag collapses any
+      // number of dropped triggers into a single follow-up.
+      if (this.pendingRefresh) {
+        this.pendingRefresh = false;
+        setTimeout(() => this.refreshData(), 0);
+      }
     }
   }
 
   dispose(): void {
     if (this.refreshTimer) {
-      clearInterval(this.refreshTimer);
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = undefined;
     }
     this.stopFileWatching();
     this.statusBar.dispose();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,10 @@ export class ClaudeCodeUsageExtension {
   // refresh cadence: while Claude Code is actively writing we refresh faster
   // (~15 s, quota cache 20 s); when idle we fall back to the user's interval.
   private lastActivityAt: number = 0;
+  // Generation token for the self-rescheduling refresh timer. Bumped each time
+  // startAutoRefresh runs so any older timer chain (e.g. left mid-flight by a
+  // config change) stops instead of running concurrently with the new one.
+  private refreshGen: number = 0;
 
   constructor(private context: vscode.ExtensionContext) {
     console.log('Claude Code Usage Extension: Constructor called');
@@ -409,11 +413,19 @@ export class ClaudeCodeUsageExtension {
     // already covers near-real-time status-bar cost updates during activity —
     // this floor guarantees the quota also refreshes during sustained writes
     // where the debounce never settles.
+    const gen = ++this.refreshGen;
     const tick = (): void => {
+      if (gen !== this.refreshGen) {
+        return; // superseded by a newer startAutoRefresh — stop this chain
+      }
       const base = Math.max(this.getConfiguration().refreshInterval * 1000, 30000);
       const intervalMs = this.isActive() ? Math.min(base, 15000) : base;
       this.refreshTimer = setTimeout(() => {
-        this.refreshData().finally(tick);
+        this.refreshData().finally(() => {
+          if (gen === this.refreshGen) {
+            tick();
+          }
+        });
       }, intervalMs);
     };
     tick();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,6 +52,10 @@ export class ClaudeCodeUsageExtension {
   // startAutoRefresh runs so any older timer chain (e.g. left mid-flight by a
   // config change) stops instead of running concurrently with the new one.
   private refreshGen: number = 0;
+  // Early-retry counter for the quota fetch: when a window opens on a cold /
+  // flaky network and the first /usage fetch fails, retry with backoff so the
+  // indicator appears without waiting for the next regular tick.
+  private quotaRetryCount: number = 0;
 
   constructor(private context: vscode.ExtensionContext) {
     console.log('Claude Code Usage Extension: Constructor called');
@@ -419,7 +423,9 @@ export class ClaudeCodeUsageExtension {
         return; // superseded by a newer startAutoRefresh — stop this chain
       }
       const base = Math.max(this.getConfiguration().refreshInterval * 1000, 30000);
-      const intervalMs = this.isActive() ? Math.min(base, 15000) : base;
+      // ~8 s while active: high-consumption models (Fable 5) move the numbers
+      // fast enough that 15 s reads as laggy.
+      const intervalMs = this.isActive() ? Math.min(base, 8000) : base;
       this.refreshTimer = setTimeout(() => {
         this.refreshData().finally(() => {
           if (gen === this.refreshGen) {
@@ -441,7 +447,7 @@ export class ClaudeCodeUsageExtension {
     // quota keeps pace during high-consumption ultracode runs), 120 s when
     // idle (avoids hammering /usage on every file-watch tick). The /usage
     // client has its own 429 cool-down, so 20 s is safe.
-    const ttl = this.isActive() ? 20000 : 120000;
+    const ttl = this.isActive() ? 15000 : 120000;
     // Bypass the cache when a cached window has already reset — otherwise the
     // status bar would show the rolled-forward 0% estimate for up to a full
     // TTL before the real new-window value arrives.
@@ -489,12 +495,28 @@ export class ClaudeCodeUsageExtension {
       // refreshes everything so the user can force-update on demand.
       const updateWebview = manualTrigger || !config.pauseDashboardRefresh;
 
-      // Quota is account-level, decoupled from local data. Refresh and push
-      // it unconditionally, even when the workspace has no Claude history or
-      // when something later fails — otherwise opening VS Code in a fresh
-      // project would hide a quota indicator that ought to be account-wide.
-      const usageLimits = await this.maybeFetchUsageLimits(config);
-      this.statusBar.updateQuota(usageLimits);
+      // Quota is account-level, decoupled from local data. Fire it without
+      // awaiting so a slow/cold OAuth fetch (curl can take seconds, or fail
+      // outright on a fresh window's flaky network) never delays the local
+      // cost figures — the cause of "usage not showing the first time I open
+      // VS Code". When the first fetch yields nothing, retry a few times with
+      // backoff instead of waiting for the next regular tick.
+      this.maybeFetchUsageLimits(config).then((limits) => {
+        this.statusBar.updateQuota(limits);
+        if (limits) {
+          this.quotaRetryCount = 0;
+        } else if (this.quotaRetryCount < 3) {
+          this.quotaRetryCount++;
+          setTimeout(() => {
+            this.maybeFetchUsageLimits(this.getConfiguration()).then((retry) => {
+              if (retry) {
+                this.quotaRetryCount = 0;
+                this.statusBar.updateQuota(retry);
+              }
+            });
+          }, 10000 * this.quotaRetryCount);
+        }
+      });
 
       // Find Claude data directory
       const dataDirectory = await ClaudeDataLoader.findClaudeDataDirectory(
@@ -574,9 +596,9 @@ export class ClaudeCodeUsageExtension {
       const projectBreakdown = ClaudeDataLoader.getProjectBreakdown(records, undefined, config.projectGroupingMode);
       const branchBreakdown = ClaudeDataLoader.getBranchBreakdown(records);
 
-      // Update UI — quota was already pushed above, so we pass it again only
-      // to keep the success-path signature stable.
-      this.statusBar.updateUsageData(todayData, workspaceTodayData, undefined, usageLimits);
+      // Update UI. Quota is pushed asynchronously by the fire-and-forget fetch
+      // above; passing undefined leaves the quota item untouched here.
+      this.statusBar.updateUsageData(todayData, workspaceTodayData, undefined, undefined);
       if (updateWebview) {
         this.webviewProvider.updateData(sessionData, todayData, monthData, allTimeData, dailyDataForMonth, dailyDataForAllTime, hourlyDataForToday, undefined, dataDirectory, records, sessionBreakdown, projectBreakdown, contentAnalysis, branchBreakdown);
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -430,7 +430,10 @@ export class ClaudeCodeUsageExtension {
     // idle (avoids hammering /usage on every file-watch tick). The /usage
     // client has its own 429 cool-down, so 20 s is safe.
     const ttl = this.isActive() ? 20000 : 120000;
-    if (this.cache.usageLimits && age < ttl) {
+    // Bypass the cache when a cached window has already reset — otherwise the
+    // status bar would show the rolled-forward 0% estimate for up to a full
+    // TTL before the real new-window value arrives.
+    if (this.cache.usageLimits && age < ttl && !this.hasExpiredWindow(this.cache.usageLimits)) {
       return this.cache.usageLimits;
     }
     const fetched = await this.apiClient.fetchUsageLimits();
@@ -441,6 +444,20 @@ export class ClaudeCodeUsageExtension {
     }
     // Keep showing the last known value if a refresh fails.
     return this.cache.usageLimits;
+  }
+
+  /** True if any usage window's reset time has already passed (so the cached
+   * utilisation is stale and a refetch is warranted). */
+  private hasExpiredWindow(u: ClaudeApiUsageResponse): boolean {
+    const now = Date.now();
+    const expired = (w?: { resets_at: string }): boolean => {
+      if (!w) {
+        return false;
+      }
+      const t = Date.parse(w.resets_at);
+      return !isNaN(t) && t <= now;
+    };
+    return expired(u.five_hour) || expired(u.seven_day) || expired(u.seven_day_opus);
   }
 
   private async refreshData(manualTrigger: boolean = false): Promise<void> {
@@ -528,12 +545,14 @@ export class ClaudeCodeUsageExtension {
       }
 
       // Calculate usage data
-      // Scope the "current session" to this window's workspace so different
-      // workspaces show their own current conversation rather than a shared
-      // global figure.
       const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      // "Current session" (per-workspace) is still computed for the webview.
       const sessionData = ClaudeDataLoader.getCurrentSessionData(records, workspacePath);
       const todayData = ClaudeDataLoader.getTodayData(records);
+      // Status-bar secondary number: today's cost for the current workspace.
+      const workspaceTodayData = workspacePath
+        ? ClaudeDataLoader.getTodayData(ClaudeDataLoader.filterByWorkspace(records, workspacePath))
+        : null;
       const monthData = ClaudeDataLoader.getThisMonthData(records);
       const allTimeData = ClaudeDataLoader.getAllTimeData(records);
       const dailyDataForMonth = ClaudeDataLoader.getDailyDataForMonth(records);
@@ -545,7 +564,7 @@ export class ClaudeCodeUsageExtension {
 
       // Update UI — quota was already pushed above, so we pass it again only
       // to keep the success-path signature stable.
-      this.statusBar.updateUsageData(todayData, sessionData, undefined, usageLimits);
+      this.statusBar.updateUsageData(todayData, workspaceTodayData, undefined, usageLimits);
       if (updateWebview) {
         this.webviewProvider.updateData(sessionData, todayData, monthData, allTimeData, dailyDataForMonth, dailyDataForAllTime, hourlyDataForToday, undefined, dataDirectory, records, sessionBreakdown, projectBreakdown, contentAnalysis, branchBreakdown);
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,10 +52,10 @@ export class ClaudeCodeUsageExtension {
   // startAutoRefresh runs so any older timer chain (e.g. left mid-flight by a
   // config change) stops instead of running concurrently with the new one.
   private refreshGen: number = 0;
-  // Early-retry counter for the quota fetch: when a window opens on a cold /
-  // flaky network and the first /usage fetch fails, retry with backoff so the
-  // indicator appears without waiting for the next regular tick.
-  private quotaRetryCount: number = 0;
+  // One-shot cold-start retry for the quota fetch: when a window opens on a
+  // flaky network and the very first /usage fetch fails, try once more shortly
+  // after so the indicator appears without waiting for the next regular tick.
+  private quotaColdRetryDone: boolean = false;
 
   constructor(private context: vscode.ExtensionContext) {
     console.log('Claude Code Usage Extension: Constructor called');
@@ -447,7 +447,11 @@ export class ClaudeCodeUsageExtension {
     // quota keeps pace during high-consumption ultracode runs), 120 s when
     // idle (avoids hammering /usage on every file-watch tick). The /usage
     // client has its own 429 cool-down, so 20 s is safe.
-    const ttl = this.isActive() ? 15000 : 120000;
+    // Quota changes slowly (a coarse %), and /usage is an undocumented
+    // endpoint that 429s if hit too often. Keep this well above the local
+    // refresh cadence: 60 s while active, 120 s idle. Local cost still updates
+    // every ~8 s via the fs watcher — only the quota number is throttled.
+    const ttl = this.isActive() ? 60000 : 120000;
     // Bypass the cache when a cached window has already reset — otherwise the
     // status bar would show the rolled-forward 0% estimate for up to a full
     // TTL before the real new-window value arrives.
@@ -499,22 +503,20 @@ export class ClaudeCodeUsageExtension {
       // awaiting so a slow/cold OAuth fetch (curl can take seconds, or fail
       // outright on a fresh window's flaky network) never delays the local
       // cost figures — the cause of "usage not showing the first time I open
-      // VS Code". When the first fetch yields nothing, retry a few times with
-      // backoff instead of waiting for the next regular tick.
+      // VS Code". On a cold start with no quota yet, do ONE gentle retry after
+      // ~8 s; beyond that the regular ticks take over. We deliberately do not
+      // retry-storm: repeated /usage hits are what trigger the 429 cool-down.
       this.maybeFetchUsageLimits(config).then((limits) => {
         this.statusBar.updateQuota(limits);
-        if (limits) {
-          this.quotaRetryCount = 0;
-        } else if (this.quotaRetryCount < 3) {
-          this.quotaRetryCount++;
+        if (!limits && !this.cache.usageLimits && !this.quotaColdRetryDone) {
+          this.quotaColdRetryDone = true;
           setTimeout(() => {
             this.maybeFetchUsageLimits(this.getConfiguration()).then((retry) => {
               if (retry) {
-                this.quotaRetryCount = 0;
                 this.statusBar.updateQuota(retry);
               }
             });
-          }, 10000 * this.quotaRetryCount);
+          }, 8000);
         }
       });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -528,7 +528,11 @@ export class ClaudeCodeUsageExtension {
       }
 
       // Calculate usage data
-      const sessionData = ClaudeDataLoader.getCurrentSessionData(records);
+      // Scope the "current session" to this window's workspace so different
+      // workspaces show their own current conversation rather than a shared
+      // global figure.
+      const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const sessionData = ClaudeDataLoader.getCurrentSessionData(records, workspacePath);
       const todayData = ClaudeDataLoader.getTodayData(records);
       const monthData = ClaudeDataLoader.getThisMonthData(records);
       const allTimeData = ClaudeDataLoader.getAllTimeData(records);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -14,6 +14,7 @@ export interface Translations {
     today: string;
     thisMonth: string;
     allTime: string;
+    workspaceToday: string;
     refresh: string;
     autoRefresh: string;
     settings: string;
@@ -106,6 +107,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       today: 'Today',
       thisMonth: 'This Month',
       allTime: 'All Time',
+      workspaceToday: 'This project',
       refresh: 'Refresh',
       autoRefresh: 'Auto refresh',
       settings: 'Settings',
@@ -207,6 +209,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       today: "Heute",
       thisMonth: "Diesen Monat",
       allTime: "Seit Aufzeichnungsbeginn",
+      workspaceToday: "Dieses Projekt",
       refresh: "Aktualisieren",
       autoRefresh: "Auto-Aktualisierung",
       settings: "Einstellungen",
@@ -311,6 +314,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       today: '今日',
       thisMonth: '本月',
       allTime: '所有',
+      workspaceToday: '本專案',
       refresh: '重新整理',
       autoRefresh: '自動刷新',
       settings: '設定',
@@ -412,6 +416,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       today: '今日',
       thisMonth: '本月',
       allTime: '所有',
+      workspaceToday: '本项目',
       refresh: '刷新',
       autoRefresh: '自动刷新',
       settings: '设置',
@@ -513,6 +518,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       today: '今日',
       thisMonth: '今月',
       allTime: 'すべて',
+      workspaceToday: 'このプロジェクト',
       refresh: '更新',
       autoRefresh: '自動更新',
       settings: '設定',
@@ -615,6 +621,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       today: '오늘',
       thisMonth: '이번 달',
       allTime: '전체',
+      workspaceToday: '이 프로젝트',
       refresh: '새로고침',
       autoRefresh: '자동 새로고침',
       settings: '설정',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -68,6 +68,7 @@ export interface Translations {
     branches: string;
     branchBreakdown: string;
     branch: string;
+    sessionTitle: string;
     getAdvice: string;
     adviceNeedsKey: string;
     adviceGenerating: string;
@@ -161,6 +162,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       branches: 'Branches',
       branchBreakdown: 'Branch Usage',
       branch: 'Branch',
+      sessionTitle: 'Session',
       getAdvice: 'Get AI Advice',
       adviceNeedsKey: 'Set an API key in Settings to use AI advice.',
       adviceGenerating: 'Generating usage advice…',
@@ -263,6 +265,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       branches: "Branches",
       branchBreakdown: "Nutzung nach Branch",
       branch: "Branch",
+      sessionTitle: "Sitzung",
       getAdvice: "KI-Rat holen",
       adviceNeedsKey: "API-Schlüssel in den Einstellungen festlegen, um KI-Rat zu nutzen.",
       adviceGenerating: "Nutzungsrat wird erstellt…",
@@ -368,6 +371,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       branches: '分支',
       branchBreakdown: '各分支使用量',
       branch: '分支',
+      sessionTitle: '會話',
       getAdvice: '取得 AI 建議',
       adviceNeedsKey: '請先在設定中填入 API 金鑰以使用 AI 建議。',
       adviceGenerating: '正在產生使用建議…',
@@ -470,6 +474,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       branches: '分支',
       branchBreakdown: '各分支使用量',
       branch: '分支',
+      sessionTitle: '会话',
       getAdvice: '获取 AI 建议',
       adviceNeedsKey: '请先在设置中填入 API 密钥以使用 AI 建议。',
       adviceGenerating: '正在生成使用建议…',
@@ -572,6 +577,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       branches: 'ブランチ',
       branchBreakdown: 'ブランチ別使用量',
       branch: 'ブランチ',
+      sessionTitle: 'セッション',
       getAdvice: 'AI アドバイスを取得',
       adviceNeedsKey: '設定で API キーを入力してください。',
       adviceGenerating: '使用アドバイスを生成中…',
@@ -675,6 +681,7 @@ const translations: Record<SupportedLanguage, Translations> = {
       branches: '브랜치',
       branchBreakdown: '브랜치별 사용량',
       branch: '브랜치',
+      sessionTitle: '세션',
       getAdvice: 'AI 조언 받기',
       adviceNeedsKey: '설정에서 API 키를 입력하세요.',
       adviceGenerating: '사용 조언 생성 중…',

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -27,7 +27,16 @@ const MILL = 1_000_000;
 // `cache_creation_input_token_cost` below uses the 5-minute write rate.
 // =====================================================================
 
-// Opus 4.5 / 4.6 / 4.7 — current Opus tier ($5 / $25)
+// Fable 5 / Mythos 5 — frontier tier ($10 / $50), verified 2026-06-09
+// https://platform.claude.com/docs/en/about-claude/pricing
+const FABLE_5: ModelPricing = {
+  input_cost_per_token: 10 / MILL,
+  output_cost_per_token: 50 / MILL,
+  cache_creation_input_token_cost: 12.5 / MILL,
+  cache_read_input_token_cost: 1 / MILL,
+};
+
+// Opus 4.5 / 4.6 / 4.7 / 4.8 — current Opus tier ($5 / $25)
 const OPUS_CURRENT: ModelPricing = {
   input_cost_per_token: 5 / MILL,
   output_cost_per_token: 25 / MILL,
@@ -144,9 +153,12 @@ const NON_CLAUDE_PRICING: Record<string, ModelPricing> = {
 // so direct lookups stay fast; anything not listed is resolved by getModelPricing()'s
 // family-aware fallback below.
 const MODEL_PRICING: Record<string, ModelPricing> = {
-  // Claude Opus 4.8 / 4.7 / 4.6 — assumed at the current Opus tier rate
-  // ($5 / $25 / $6.25 / $0.5 per MTok). If Anthropic later differentiates
-  // Opus 4.8 pricing, override here or pull via "Refresh Token Pricing".
+  // Claude Fable 5 / Mythos 5 (2026-06) — frontier tier
+  'claude-fable-5': FABLE_5,
+  'claude-mythos-5': FABLE_5,
+
+  // Claude Opus 4.8 / 4.7 / 4.6 — current Opus tier rate, verified 2026-06-09
+  // against the official pricing page ($5 / $25 / $6.25 / $0.5 per MTok).
   'claude-opus-4-8': OPUS_CURRENT,
   'claude-opus-4-7': OPUS_CURRENT,
   'claude-opus-4-6': OPUS_CURRENT,
@@ -205,6 +217,9 @@ function inferPricingByFamily(modelName: string): { pricing: ModelPricing; famil
   const name = modelName.toLowerCase();
 
   // --- Anthropic / Claude ---
+  if (name.includes('fable') || name.includes('mythos')) {
+    return { pricing: FABLE_5, family: 'Fable 5 (frontier tier)' };
+  }
   if (name.includes('haiku')) {
     if (name.includes('haiku-3') || name.includes('-3-5-haiku') || name.includes('-3-haiku')) {
       return { pricing: HAIKU_35, family: 'Haiku 3.5' };
@@ -252,6 +267,12 @@ export function getModelPricing(modelName: string | undefined): ModelPricing | n
   if (!modelName) {
     return null;
   }
+
+  // Strip a trailing bracket suffix like "[1m]" (long-context variant marker
+  // used in Claude Code model settings, e.g. "claude-fable-5[1m]"). 1M-context
+  // variants are billed at standard per-token rates, so the base model's
+  // pricing applies.
+  modelName = modelName.replace(/\[[^\]]*\]\s*$/, '');
 
   // Try different variation matches (similar to ccusage logic)
   const variations = [modelName, `anthropic/${modelName}`, `claude-3-5-${modelName}`, `claude-3-${modelName}`, `claude-${modelName}`];

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -81,8 +81,16 @@ export class StatusBarManager {
    * Public so it can be refreshed on its own while the rest of the UI is idle.
    */
   updateQuota(usageLimits: ClaudeApiUsageResponse | null): void {
-    const fiveHour = usageLimits?.five_hour;
-    const weekly = usageLimits?.seven_day;
+    // A window's utilization is a point-in-time snapshot only valid until its
+    // resets_at. When the OAuth fetch starts failing (expired creds, 401/403,
+    // offline, rate-limited), maybeFetchUsageLimits keeps handing us the last
+    // successful response — so without this guard we'd keep rendering a value
+    // long after its window rolled over (e.g. a stale "5h:100%" lingering for
+    // hours, even after a plan upgrade or a reset). Drop any window whose reset
+    // time has passed. Adapted from PR #24 by @nickearnshaw.
+    const live = this.liveWindows(usageLimits);
+    const fiveHour = live?.five_hour;
+    const weekly = live?.seven_day;
     if (!fiveHour && !weekly) {
       this.quotaItem.hide();
       return;
@@ -110,8 +118,40 @@ export class StatusBarManager {
       this.quotaItem.backgroundColor = undefined;
     }
 
-    this.quotaItem.tooltip = this.createQuotaTooltip(usageLimits as ClaudeApiUsageResponse);
+    this.quotaItem.tooltip = this.createQuotaTooltip(live as ClaudeApiUsageResponse);
     this.quotaItem.show();
+  }
+
+  /**
+   * Return a copy of the usage response containing only windows still inside
+   * their current period. A window whose resets_at has already passed has
+   * rolled over, so its cached utilization is stale and must not be shown.
+   * A window with an unparseable resets_at is kept (we don't hide data we
+   * can't reason about). Returns null when nothing current remains, which
+   * collapses the indicator instead of showing a wrong figure.
+   * Adapted from PR #24 by @nickearnshaw.
+   */
+  private liveWindows(usageLimits: ClaudeApiUsageResponse | null): ClaudeApiUsageResponse | null {
+    if (!usageLimits) {
+      return null;
+    }
+    const now = Date.now();
+    const current = (limit?: ClaudeUsageLimit): ClaudeUsageLimit | undefined => {
+      if (!limit) {
+        return undefined;
+      }
+      const t = Date.parse(limit.resets_at);
+      return isNaN(t) || t > now ? limit : undefined;
+    };
+    const out: ClaudeApiUsageResponse = {
+      five_hour: current(usageLimits.five_hour),
+      seven_day: current(usageLimits.seven_day),
+      seven_day_opus: current(usageLimits.seven_day_opus)
+    };
+    if (!out.five_hour && !out.seven_day && !out.seven_day_opus) {
+      return null;
+    }
+    return out;
   }
 
   private showNoData(): void {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ClaudeApiUsageResponse, ClaudeUsageLimit, SessionData, UsageData } from './types';
+import { ClaudeApiUsageResponse, ClaudeUsageLimit, UsageData } from './types';
 import { I18n } from './i18n';
 
 export class StatusBarManager {
@@ -26,7 +26,7 @@ export class StatusBarManager {
 
   updateUsageData(
     todayData: UsageData | null,
-    sessionData?: SessionData | null,
+    workspaceTodayData?: UsageData | null,
     error?: string,
     usageLimits?: ClaudeApiUsageResponse | null
   ): void {
@@ -45,7 +45,7 @@ export class StatusBarManager {
       return;
     }
 
-    this.showTodayData(todayData, sessionData ?? null);
+    this.showTodayData(todayData, workspaceTodayData ?? null);
     // The usageLimits arg is kept for callers that want a single-call update
     // path; quota was already refreshed earlier in this cycle.
     if (usageLimits !== undefined) {
@@ -61,17 +61,20 @@ export class StatusBarManager {
     }
   }
 
-  private showTodayData(todayData: UsageData, sessionData: SessionData | null): void {
+  private showTodayData(todayData: UsageData, workspaceTodayData: UsageData | null): void {
     const todayCost = I18n.formatCurrency(todayData.totalCost);
-    // Primary number = today's cost. When an active session exists, show its
-    // cost as a secondary value so per-session spend is visible at a glance.
+    // Primary number = today's total cost across all projects. Secondary number
+    // = today's cost for the current workspace, so you can see this project's
+    // share next to the global total. Both reset at midnight (stable), unlike
+    // the old "current session" which vanished after 5h idle.
     let text = `$(pulse) ${todayCost}`;
-    if (sessionData && sessionData.messageCount > 0) {
-      text += ` $(history) ${I18n.formatCurrency(sessionData.totalCost)}`;
+    const ws = workspaceTodayData && workspaceTodayData.totalCost > 0 ? workspaceTodayData : null;
+    if (ws) {
+      text += ` $(folder) ${I18n.formatCurrency(ws.totalCost)}`;
     }
     this.statusBarItem.text = text;
 
-    this.statusBarItem.tooltip = this.createTooltip(todayData, sessionData);
+    this.statusBarItem.tooltip = this.createTooltip(todayData, ws);
     this.statusBarItem.backgroundColor = undefined;
   }
 
@@ -136,17 +139,36 @@ export class StatusBarManager {
       return null;
     }
     const now = Date.now();
-    const current = (limit?: ClaudeUsageLimit): ClaudeUsageLimit | undefined => {
+    const H5 = 5 * 60 * 60 * 1000;
+    const WEEK = 7 * 24 * 60 * 60 * 1000;
+    // A window's utilization is a point-in-time snapshot valid until resets_at.
+    // Once that passes the window has rolled over: utilisation is back at 0 for
+    // the new period. Rather than show a stale value (the old #24 bug) or hide
+    // the row entirely (which looked like the indicator vanished), we display
+    // 0% and roll the reset time forward by whole periods so the countdown is
+    // sensible. A forced refetch (see extension.maybeFetchUsageLimits) then
+    // replaces this estimate with the real new-window value shortly after.
+    const roll = (limit: ClaudeUsageLimit | undefined, periodMs: number): ClaudeUsageLimit | undefined => {
       if (!limit) {
         return undefined;
       }
       const t = Date.parse(limit.resets_at);
-      return isNaN(t) || t > now ? limit : undefined;
+      if (isNaN(t)) {
+        return limit; // unparseable — don't reason about it, keep as-is
+      }
+      if (t > now) {
+        return limit; // still current
+      }
+      let next = t;
+      while (next <= now) {
+        next += periodMs;
+      }
+      return { utilization: 0, resets_at: new Date(next).toISOString() };
     };
     const out: ClaudeApiUsageResponse = {
-      five_hour: current(usageLimits.five_hour),
-      seven_day: current(usageLimits.seven_day),
-      seven_day_opus: current(usageLimits.seven_day_opus)
+      five_hour: roll(usageLimits.five_hour, H5),
+      seven_day: roll(usageLimits.seven_day, WEEK),
+      seven_day_opus: roll(usageLimits.seven_day_opus, WEEK)
     };
     if (!out.five_hour && !out.seven_day && !out.seven_day_opus) {
       return null;
@@ -170,15 +192,15 @@ export class StatusBarManager {
    * Hover tooltip as a Markdown table so figures line up in neat, right-aligned
    * columns (a plain-text tooltip cannot align reliably).
    */
-  private createTooltip(todayData: UsageData, sessionData: SessionData | null): vscode.MarkdownString {
+  private createTooltip(todayData: UsageData, workspaceTodayData: UsageData | null): vscode.MarkdownString {
     const t = I18n.t.popup;
-    const session = sessionData && sessionData.messageCount > 0 ? sessionData : null;
+    const ws = workspaceTodayData && workspaceTodayData.totalCost > 0 ? workspaceTodayData : null;
 
     const md = new vscode.MarkdownString();
     md.supportThemeIcons = true;
 
-    if (session) {
-      md.appendMarkdown(`| | $(pulse) ${t.today} | $(history) ${I18n.t.statusBar.currentSession} |\n`);
+    if (ws) {
+      md.appendMarkdown(`| | $(pulse) ${t.today} | $(folder) ${t.workspaceToday} |\n`);
       md.appendMarkdown(`|:--|--:|--:|\n`);
     } else {
       md.appendMarkdown(`| | $(pulse) ${t.today} |\n`);
@@ -186,31 +208,31 @@ export class StatusBarManager {
     }
 
     const row = (label: string, todayValue: string, sessionValue: string): void => {
-      md.appendMarkdown(session ? `| ${label} | ${todayValue} | ${sessionValue} |\n` : `| ${label} | ${todayValue} |\n`);
+      md.appendMarkdown(ws ? `| ${label} | ${todayValue} | ${sessionValue} |\n` : `| ${label} | ${todayValue} |\n`);
     };
 
-    row(t.cost, I18n.formatCurrency(todayData.totalCost), session ? I18n.formatCurrency(session.totalCost) : '');
+    row(t.cost, I18n.formatCurrency(todayData.totalCost), ws ? I18n.formatCurrency(ws.totalCost) : '');
     row(
       t.inputTokens,
       I18n.formatNumber(todayData.totalInputTokens),
-      session ? I18n.formatNumber(session.totalInputTokens) : ''
+      ws ? I18n.formatNumber(ws.totalInputTokens) : ''
     );
     row(
       t.outputTokens,
       I18n.formatNumber(todayData.totalOutputTokens),
-      session ? I18n.formatNumber(session.totalOutputTokens) : ''
+      ws ? I18n.formatNumber(ws.totalOutputTokens) : ''
     );
     row(
       t.cacheCreation,
       I18n.formatNumber(todayData.totalCacheCreationTokens),
-      session ? I18n.formatNumber(session.totalCacheCreationTokens) : ''
+      ws ? I18n.formatNumber(ws.totalCacheCreationTokens) : ''
     );
     row(
       t.cacheRead,
       I18n.formatNumber(todayData.totalCacheReadTokens),
-      session ? I18n.formatNumber(session.totalCacheReadTokens) : ''
+      ws ? I18n.formatNumber(ws.totalCacheReadTokens) : ''
     );
-    row(t.messages, I18n.formatNumber(todayData.messageCount), session ? I18n.formatNumber(session.messageCount) : '');
+    row(t.messages, I18n.formatNumber(todayData.messageCount), ws ? I18n.formatNumber(ws.messageCount) : '');
 
     md.appendMarkdown(`\n\n*Click for detailed breakdown*`);
     return md;

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -16,7 +16,11 @@ export class StatusBarManager {
     this.quotaItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99);
     this.quotaItem.command = 'claudeCodeUsage.showDetails';
 
-    this.updateStatusBar();
+    // Visible from t=0: an empty-text status bar item renders as nothing, so
+    // without this the extension appears "missing" until the first full
+    // refresh lands (which can lag behind a slow first quota fetch on a cold
+    // network). Reported as "usage not showing the first time I open VS Code".
+    this.setLoading(true);
   }
 
   setLoading(loading: boolean): void {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -159,6 +159,14 @@ export class StatusBarManager {
       if (t > now) {
         return limit; // still current
       }
+      // Expired. If it reset only recently (within ~2 periods), the data is
+      // simply waiting for the next refetch — show 0% for the fresh window.
+      // But if it expired long ago, the fetch has been failing for ages and we
+      // have no trustworthy data: drop it rather than assert a fabricated 0%
+      // (which would falsely imply "full quota available").
+      if (now - t > 2 * periodMs) {
+        return undefined;
+      }
       let next = t;
       while (next <= now) {
         next += periodMs;

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -68,7 +68,10 @@ export class StatusBarManager {
     // share next to the global total. Both reset at midnight (stable), unlike
     // the old "current session" which vanished after 5h idle.
     let text = `$(pulse) ${todayCost}`;
-    const ws = workspaceTodayData && workspaceTodayData.totalCost > 0 ? workspaceTodayData : null;
+    // Show the workspace figure whenever a workspace is open — including
+    // $0.00. Hiding it at zero made the item appear and disappear through the
+    // day, which read as a bug ("where did my number go?").
+    const ws = workspaceTodayData ?? null;
     if (ws) {
       text += ` $(folder) ${I18n.formatCurrency(ws.totalCost)}`;
     }
@@ -202,7 +205,7 @@ export class StatusBarManager {
    */
   private createTooltip(todayData: UsageData, workspaceTodayData: UsageData | null): vscode.MarkdownString {
     const t = I18n.t.popup;
-    const ws = workspaceTodayData && workspaceTodayData.totalCost > 0 ? workspaceTodayData : null;
+    const ws = workspaceTodayData;
 
     const md = new vscode.MarkdownString();
     md.supportThemeIcons = true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,9 +20,16 @@ export interface ClaudeUsageRecord {
   _projectName?: string;
   _projectPath?: string;
   _gitBranch?: string;
-  // Human-readable conversation title from the session's `summary` log line
-  // (what `claude --resume` shows). Populated post-load per session.
+  // Human-readable conversation title (what `claude --resume` shows),
+  // harvested from `custom-title` / `ai-title` / legacy `summary` log lines.
   _sessionTitle?: string;
+  // Encoded project directory the session file lives in (where the session
+  // was started), e.g. "d--Jiaming-My-Proj". Stable per session, unlike the
+  // per-record cwd which wanders as work moves between folders.
+  _projectDirEncoded?: string;
+  // Synthetic marker record for one genuine user prompt (zero usage).
+  // messageCount counts these, so "Messages" means what users typed.
+  _isUserPrompt?: boolean;
 }
 
 export interface UsageData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,9 @@ export interface ClaudeUsageRecord {
   _projectName?: string;
   _projectPath?: string;
   _gitBranch?: string;
+  // Human-readable conversation title from the session's `summary` log line
+  // (what `claude --resume` shows). Populated post-load per session.
+  _sessionTitle?: string;
 }
 
 export interface UsageData {
@@ -54,6 +57,8 @@ export interface SessionData extends UsageData {
 // Per-conversation breakdown: one entry per Claude Code session (.jsonl file).
 export interface SessionUsage {
   sessionId: string;
+  // Conversation title (from the session's summary line), when available.
+  title?: string;
   projectName: string;
   projectPath: string;
   startTime: Date;

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -1391,32 +1391,37 @@ export class UsageWebviewProvider {
    * preserved by making the cost segments pointer-events:none so clicks reach
    * the parent .chart-bar.clickable.
    */
+  /** Stacked cost segments for one bar (input / cache-read / cache-write /
+   * output), heights proportional to each component's share of the bar's
+   * cost. Order + colours match renderCompositionChart. Shared by the daily /
+   * monthly and today-hourly cost charts. */
+  private costStackHtml(data: UsageData, barHeight: number): string {
+    const t = I18n.t.popup;
+    const cb = data.costBreakdown;
+    const total = cb.input + cb.output + cb.cacheWrite + cb.cacheRead;
+    const seg = (value: number, cls: string, label: string): string => {
+      const h = total > 0 ? (value / total) * barHeight : 0;
+      return (
+        '<div class="stack-seg ' + cls + '" style="height: ' + h + 'px;" title="' +
+        this.escapeHtml(label) + ': ' + I18n.formatCurrency(value) + '"></div>'
+      );
+    };
+    return (
+      seg(cb.input, 'seg-input', t.inputTokens) +
+      seg(cb.cacheRead, 'seg-cache-read', t.cacheRead) +
+      seg(cb.cacheWrite, 'seg-cache-creation', t.cacheCreation) +
+      seg(cb.output, 'seg-output', t.outputTokens)
+    );
+  }
+
   private renderMainCostChart(sortedData: { date: string; data: UsageData }[]): string {
     if (sortedData.length === 0) {
       return '<div class="no-chart-data">No data available</div>';
     }
-    const t = I18n.t.popup;
     const maxCost = Math.max(...sortedData.map((d) => d.data.totalCost), 0);
     const maxHeight = 120;
 
-    const costStack = (data: UsageData, barHeight: number): string => {
-      const cb = data.costBreakdown;
-      const total = cb.input + cb.output + cb.cacheWrite + cb.cacheRead;
-      const seg = (value: number, cls: string, label: string): string => {
-        const h = total > 0 ? (value / total) * barHeight : 0;
-        return (
-          '<div class="stack-seg ' + cls + '" style="height: ' + h + 'px;" title="' +
-          this.escapeHtml(label) + ': ' + I18n.formatCurrency(value) + '"></div>'
-        );
-      };
-      // Order matches renderCompositionChart: input, cache-read, cache-write, output.
-      return (
-        seg(cb.input, 'seg-input', t.inputTokens) +
-        seg(cb.cacheRead, 'seg-cache-read', t.cacheRead) +
-        seg(cb.cacheWrite, 'seg-cache-creation', t.cacheCreation) +
-        seg(cb.output, 'seg-output', t.outputTokens)
-      );
-    };
+    const costStack = (data: UsageData, barHeight: number): string => this.costStackHtml(data, barHeight);
 
     const bars = sortedData
       .map(({ date, data }) => {
@@ -1484,17 +1489,24 @@ export class UsageWebviewProvider {
     const bars = sortedData
       .map(({ hour, data }) => {
         const height = maxCost > 0 ? (data.totalCost / maxCost) * maxHeight : 0;
+        const cb = data.costBreakdown;
         return (
           '<div class="hc-col" data-hour="' + hour + '">' +
           '<div class="hc-barval">' + I18n.formatCurrency(data.totalCost) + '</div>' +
-          '<div class="chart-bar cost-bar" style="height: ' + height + 'px;" ' +
+          '<div class="chart-bar cost-bar cost-stacked" style="height: ' + height + 'px;" ' +
           'data-cost="' + data.totalCost + '" ' +
           'data-input="' + data.totalInputTokens + '" ' +
           'data-output="' + data.totalOutputTokens + '" ' +
           'data-cache-creation="' + data.totalCacheCreationTokens + '" ' +
           'data-cache-read="' + data.totalCacheReadTokens + '" ' +
           'data-messages="' + data.messageCount + '" ' +
-          'title="' + I18n.formatCurrency(data.totalCost) + '"></div>' +
+          'data-cost-input="' + cb.input + '" ' +
+          'data-cost-output="' + cb.output + '" ' +
+          'data-cost-cachewrite="' + cb.cacheWrite + '" ' +
+          'data-cost-cacheread="' + cb.cacheRead + '" ' +
+          'title="' + I18n.formatCurrency(data.totalCost) + '">' +
+          this.costStackHtml(data, height) +
+          '</div>' +
           '</div>'
         );
       })
@@ -2672,6 +2684,11 @@ function toggleHourlyDetail(date) {
           vscode.postMessage({ command: 'getHourlyData', date: date });
           container.dataset.loaded = 'true';
         }
+
+        // Scroll the newly-revealed detail into view — clicking a bar at the
+        // top of the tab otherwise expands a detail far down the table that
+        // the user never notices.
+        try { detailRow.scrollIntoView({ behavior: 'smooth', block: 'center' }); } catch (e) {}
       } else {
         // Hide detail
         detailRow.style.display = 'none';
@@ -2758,6 +2775,9 @@ function toggleMonthlyDetail(monthDate) {
           vscode.postMessage({ command: 'getDailyData', month: monthDate });
           container.dataset.loaded = 'true';
         }
+
+        // Scroll the newly-revealed detail into view (see toggleHourlyDetail).
+        try { detailRow.scrollIntoView({ behavior: 'smooth', block: 'center' }); } catch (e) {}
       } else {
         // Hide detail
         detailRow.style.display = 'none';
@@ -3251,146 +3271,100 @@ function renderDailyData(dailyData, monthDate) {
   return html;
 }
 
-function renderDailyChart(dailyData, metric) {
-  console.log("[DEBUG] renderDailyChart called with metric:", metric);
-
-  const maxValues = {
-    cost: Math.max(...dailyData.map(d => d.data.totalCost)),
-    inputTokens: Math.max(...dailyData.map(d => d.data.totalInputTokens)),
-    outputTokens: Math.max(...dailyData.map(d => d.data.totalOutputTokens)),
-    cacheCreation: Math.max(...dailyData.map(d => d.data.totalCacheCreationTokens)),
-    cacheRead: Math.max(...dailyData.map(d => d.data.totalCacheReadTokens)),
-    messages: Math.max(...dailyData.map(d => d.data.messageCount))
-  };
-
+// Shared gridded chart for the drill-down details (daily under a month,
+// hourly under a day). Matches the server-rendered main charts: a Y-axis,
+// two dashed reference lines, and — for the cost metric — stacked
+// composition bars (input / cache-read / cache-write / output). Other metrics
+// render single-colour bars. Each bar carries the cost breakdown as data
+// attributes so the in-place metric switcher (updateMainChart) can rebuild.
+function griddedChart(items, metric, opts) {
+  if (!items || items.length === 0) {
+    return '<div class="no-chart-data">No data available</div>';
+  }
   const maxHeight = 120;
-  const maxValue = maxValues[metric] || 0;
-
-  let html = '<div class="chart-bars">';
-
-  dailyData.forEach(function(item) {
-    let value = 0;
-    let barClass = 'cost-bar';
-
-    switch(metric) {
-      case 'cost':
-        value = item.data.totalCost;
-        barClass = 'cost-bar';
-        break;
-      case 'inputTokens':
-        value = item.data.totalInputTokens;
-        barClass = 'input-bar';
-        break;
-      case 'outputTokens':
-        value = item.data.totalOutputTokens;
-        barClass = 'output-bar';
-        break;
-      case 'cacheCreation':
-        value = item.data.totalCacheCreationTokens;
-        barClass = 'cache-creation-bar';
-        break;
-      case 'cacheRead':
-        value = item.data.totalCacheReadTokens;
-        barClass = 'cache-read-bar';
-        break;
-      case 'messages':
-        value = item.data.messageCount;
-        barClass = 'messages-bar';
-        break;
+  function metricValue(d) {
+    switch (metric) {
+      case 'inputTokens': return d.totalInputTokens;
+      case 'outputTokens': return d.totalOutputTokens;
+      case 'cacheCreation': return d.totalCacheCreationTokens;
+      case 'cacheRead': return d.totalCacheReadTokens;
+      case 'messages': return d.messageCount;
+      default: return d.totalCost;
     }
+  }
+  const values = items.map(function(it) { return metricValue(it.data); });
+  const maxValue = Math.max.apply(null, values.concat([0]));
 
-    const height = maxValue > 0 ? Math.max((value / maxValue) * maxHeight, 2) : 2;
-    const dateObj = new Date(item.date);
-    const shortDate = dateObj.getDate().toString();
+  let bars = '';
+  items.forEach(function(it, i) {
+    const d = it.data;
+    const value = values[i];
+    const height = maxValue > 0 ? (value / maxValue) * maxHeight : 0;
+    const cb = d.costBreakdown || { input: 0, output: 0, cacheWrite: 0, cacheRead: 0 };
+    const keyAttr = opts.keyName === 'hour' ? 'data-hour' : 'data-date';
+    const key = opts.keyName === 'hour' ? it.hour : it.date;
 
-    html += '<div class="chart-bar-container" data-date="' + item.date + '">';
-    html += '<div class="chart-bar ' + barClass + '" ';
-    html += 'style="height: ' + height + 'px;" ';
-    html += 'data-cost="' + item.data.totalCost + '" ';
-    html += 'data-input="' + item.data.totalInputTokens + '" ';
-    html += 'data-output="' + item.data.totalOutputTokens + '" ';
-    html += 'data-cache-creation="' + item.data.totalCacheCreationTokens + '" ';
-    html += 'data-cache-read="' + item.data.totalCacheReadTokens + '" ';
-    html += 'data-messages="' + item.data.messageCount + '" ';
-    html += 'title="' + dateObj.toLocaleDateString(__locale, __dateOpts()) + ': ' + formatValue(value, metric) + '">';
-    html += '</div>';
-    html += '<div class="chart-label">' + shortDate + '</div>';
-    html += '</div>';
+    let inner = '';
+    let cls = 'chart-bar ' + getBarClass(metric);
+    if (metric === 'cost') {
+      cls = 'chart-bar cost-bar cost-stacked';
+      const total = cb.input + cb.output + cb.cacheWrite + cb.cacheRead;
+      function seg(v, c) {
+        const h = total > 0 ? (v / total) * height : 0;
+        return '<div class="stack-seg ' + c + '" style="height: ' + h + 'px;"></div>';
+      }
+      inner = seg(cb.input, 'seg-input') + seg(cb.cacheRead, 'seg-cache-read') +
+              seg(cb.cacheWrite, 'seg-cache-creation') + seg(cb.output, 'seg-output');
+    }
+    if (opts.clickable) { cls += ' clickable'; }
+
+    bars += '<div class="hc-col" ' + keyAttr + '="' + key + '">' +
+      '<div class="hc-barval">' + formatValue(value, metric) + '</div>' +
+      '<div class="' + cls + '" style="height: ' + height + 'px;" ' +
+      'data-cost="' + d.totalCost + '" data-input="' + d.totalInputTokens + '" data-output="' + d.totalOutputTokens + '" ' +
+      'data-cache-creation="' + d.totalCacheCreationTokens + '" data-cache-read="' + d.totalCacheReadTokens + '" data-messages="' + d.messageCount + '" ' +
+      'data-cost-input="' + cb.input + '" data-cost-output="' + cb.output + '" data-cost-cachewrite="' + cb.cacheWrite + '" data-cost-cacheread="' + cb.cacheRead + '" ' +
+      'title="' + opts.getTitle(it, value) + '">' + inner + '</div>' +
+      '</div>';
   });
 
-  html += '</div>';
+  const xlabels = items.map(function(it) {
+    return '<div class="hc-xlabel">' + opts.getLabel(it) + '</div>';
+  }).join('');
 
-  return html;
+  return '<div class="hc-wrap">' +
+    '<div class="hc-yaxis">' +
+    '<span class="hc-yval">' + formatValue(maxValue, metric) + '</span>' +
+    '<span class="hc-yval">' + formatValue(maxValue / 2, metric) + '</span>' +
+    '<span class="hc-yval">' + formatValue(0, metric) + '</span>' +
+    '</div>' +
+    '<div class="hc-main"><div class="hc-scroll">' +
+    '<div class="hc-plot"><div class="hc-grid hc-grid-top"></div><div class="hc-grid hc-grid-mid"></div>' +
+    '<div class="hc-bars">' + bars + '</div></div>' +
+    '<div class="hc-xlabels">' + xlabels + '</div>' +
+    '</div></div></div>';
+}
+
+function renderDailyChart(dailyData, metric) {
+  return griddedChart(dailyData, metric, {
+    keyName: 'date',
+    clickable: false,
+    // Show month/day (not just the day number) so the axis isn't ambiguous.
+    getLabel: function(it) { var d = new Date(it.date); return (d.getMonth() + 1) + '/' + d.getDate(); },
+    getTitle: function(it, v) {
+      var d = new Date(it.date);
+      return d.toLocaleDateString(__locale, __dateOpts()) + ': ' + formatValue(v, metric);
+    }
+  });
 }
 
 function renderHourlyChart(hourlyData, metric) {
-  console.log("[DEBUG] renderHourlyChart called with metric:", metric);
-
-  const maxValues = {
-    cost: Math.max(...hourlyData.map(d => d.data.totalCost)),
-    inputTokens: Math.max(...hourlyData.map(d => d.data.totalInputTokens)),
-    outputTokens: Math.max(...hourlyData.map(d => d.data.totalOutputTokens)),
-    cacheCreation: Math.max(...hourlyData.map(d => d.data.totalCacheCreationTokens)),
-    cacheRead: Math.max(...hourlyData.map(d => d.data.totalCacheReadTokens)),
-    messages: Math.max(...hourlyData.map(d => d.data.messageCount))
-  };
-
-  const maxHeight = 120;
-  const maxValue = maxValues[metric] || 0;
-
-  let html = '<div class="chart-bars">';
-
-  hourlyData.forEach(function(item) {
-    let value = 0;
-    let barClass = 'cost-bar';
-
-    switch(metric) {
-      case 'cost':
-        value = item.data.totalCost;
-        barClass = 'cost-bar';
-        break;
-      case 'inputTokens':
-        value = item.data.totalInputTokens;
-        barClass = 'input-bar';
-        break;
-      case 'outputTokens':
-        value = item.data.totalOutputTokens;
-        barClass = 'output-bar';
-        break;
-      case 'cacheCreation':
-        value = item.data.totalCacheCreationTokens;
-        barClass = 'cache-creation-bar';
-        break;
-      case 'cacheRead':
-        value = item.data.totalCacheReadTokens;
-        barClass = 'cache-read-bar';
-        break;
-      case 'messages':
-        value = item.data.messageCount;
-        barClass = 'messages-bar';
-        break;
-    }
-
-    const height = maxValue > 0 ? Math.max((value / maxValue) * maxHeight, 2) : 2;
-
-    html += '<div class="chart-bar-container" data-hour="' + item.hour + '">';
-    html += '<div class="chart-bar ' + barClass + '" ';
-    html += 'style="height: ' + height + 'px;" ';
-    html += 'data-cost="' + item.data.totalCost + '" ';
-    html += 'data-input="' + item.data.totalInputTokens + '" ';
-    html += 'data-output="' + item.data.totalOutputTokens + '" ';
-    html += 'data-cache-creation="' + item.data.totalCacheCreationTokens + '" ';
-    html += 'data-cache-read="' + item.data.totalCacheReadTokens + '" ';
-    html += 'data-messages="' + item.data.messageCount + '" ';
-    html += 'title="' + item.hour + ': ' + formatValue(value, metric) + '">';
-    html += '</div>';
-    html += '<div class="chart-label">' + item.hour + '</div>';
-    html += '</div>';
+  return griddedChart(hourlyData, metric, {
+    keyName: 'hour',
+    clickable: false,
+    getLabel: function(it) { return it.hour; },
+    getTitle: function(it, v) { return it.hour + ': ' + formatValue(v, metric); }
   });
-
-  html += '</div>';
-
-  return html;
 }
 
 // Initialize chart tab events for existing elements

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -3109,8 +3109,14 @@ function updateMainChart(metric, container) {
     }
   });
 
-  // Update the hourly chart's Y-axis reference labels, if present.
-  const yvals = targetContainer.querySelectorAll('.hc-yaxis .hc-yval');
+  // Update the main chart's Y-axis reference labels for the new metric.
+  // Scope to the wrap that holds the bars we just updated — the same container
+  // also holds the token-composition chart's own hc-yaxis, so a container-wide
+  // query would find 6 values (not 3) and silently skip the update, leaving
+  // the axis stuck on the previous metric's units.
+  const firstBar = chartBars[0];
+  const wrap = firstBar && firstBar.closest ? firstBar.closest('.hc-wrap') : null;
+  const yvals = wrap ? wrap.querySelectorAll('.hc-yaxis .hc-yval') : [];
   if (yvals.length === 3) {
     yvals[0].textContent = formatValue(maxValue, metric);
     yvals[1].textContent = formatValue(maxValue / 2, metric);

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -756,11 +756,9 @@ export class UsageWebviewProvider {
           <button class="chart-tab" data-metric="messages">${I18n.t.popup.messages}</button>
         </div>
 
-        <!-- Chart Container -->
-        <div class="chart-container">
-          <div class="chart-content" id="dailyChart">
-            ${this.renderDailyChart()}
-          </div>
+        <!-- Chart Container (hc-wrap is self-contained: Y-axis + gridlines + scroll) -->
+        <div class="chart-content" id="dailyChart">
+          ${this.renderDailyChart()}
         </div>
 
         ${this.renderCompositionChart(
@@ -846,11 +844,9 @@ export class UsageWebviewProvider {
           <button class="chart-tab" data-metric="messages">${I18n.t.popup.messages}</button>
         </div>
 
-        <!-- Chart Container -->
-        <div class="chart-container">
-          <div class="chart-content" id="allTimeChart">
-            ${this.renderAllTimeChart()}
-          </div>
+        <!-- Chart Container (hc-wrap is self-contained: Y-axis + gridlines + scroll) -->
+        <div class="chart-content" id="allTimeChart">
+          ${this.renderAllTimeChart()}
         </div>
 
         ${this.renderCompositionChart(
@@ -1374,79 +1370,101 @@ export class UsageWebviewProvider {
   }
 
   private renderDailyChart(): string {
-    if (this.dailyDataForMonth.length === 0) {
-      return '<div class="no-chart-data">No data available</div>';
-    }
-
-    // Sort data by date (oldest first for chart display)
     const sortedData = [...this.dailyDataForMonth].sort((a, b) => a.date.localeCompare(b.date));
-
-    // Generate chart bars for cost (default metric)
-    const maxCost = Math.max(...sortedData.map((d) => d.data.totalCost));
-    const maxHeight = 120; // Max height in pixels
-
-    return `
-      <div class="chart-bars">
-        ${sortedData
-          .map(({ date, data }) => {
-            const height = maxCost > 0 ? (data.totalCost / maxCost) * maxHeight : 0;
-            return `
-            <div class="chart-bar-container" data-date="${date}">
-              <div class="chart-bar cost-bar clickable"
-                   style="height: ${height}px;"
-                   data-cost="${data.totalCost}"
-                   data-input="${data.totalInputTokens}"
-                   data-output="${data.totalOutputTokens}"
-                   data-cache-creation="${data.totalCacheCreationTokens}"
-                   data-cache-read="${data.totalCacheReadTokens}"
-                   data-messages="${data.messageCount}"
-                   title="${this.formatDate(date)}: ${I18n.formatCurrency(data.totalCost)}">
-              </div>
-              <div class="chart-label">${this.getShortDate(date)}</div>
-            </div>
-          `;
-          })
-          .join('')}
-      </div>
-    `;
+    return this.renderMainCostChart(sortedData);
   }
 
   private renderAllTimeChart(): string {
-    if (this.dailyDataForAllTime.length === 0) {
+    const sortedData = [...this.dailyDataForAllTime].sort((a, b) => a.date.localeCompare(b.date));
+    return this.renderMainCostChart(sortedData);
+  }
+
+  /**
+   * Daily / monthly time-series chart. Default (cost) metric renders each bar
+   * as a stacked cost-composition (input / output / cache-write / cache-read,
+   * same colours as the summary's Cost Composition). A Y-axis and two dashed
+   * reference lines give scale; the metric switcher re-renders bars in place
+   * (stacked for cost, single-colour for token/message metrics).
+   *
+   * Bars carry the cost breakdown as data attributes so updateMainChart can
+   * rebuild the stack on the client without another round-trip. Drill-down is
+   * preserved by making the cost segments pointer-events:none so clicks reach
+   * the parent .chart-bar.clickable.
+   */
+  private renderMainCostChart(sortedData: { date: string; data: UsageData }[]): string {
+    if (sortedData.length === 0) {
       return '<div class="no-chart-data">No data available</div>';
     }
+    const t = I18n.t.popup;
+    const maxCost = Math.max(...sortedData.map((d) => d.data.totalCost), 0);
+    const maxHeight = 120;
 
-    // Sort data by date (oldest first for chart display)
-    const sortedData = [...this.dailyDataForAllTime].sort((a, b) => a.date.localeCompare(b.date));
+    const costStack = (data: UsageData, barHeight: number): string => {
+      const cb = data.costBreakdown;
+      const total = cb.input + cb.output + cb.cacheWrite + cb.cacheRead;
+      const seg = (value: number, cls: string, label: string): string => {
+        const h = total > 0 ? (value / total) * barHeight : 0;
+        return (
+          '<div class="stack-seg ' + cls + '" style="height: ' + h + 'px;" title="' +
+          this.escapeHtml(label) + ': ' + I18n.formatCurrency(value) + '"></div>'
+        );
+      };
+      // Order matches renderCompositionChart: input, cache-read, cache-write, output.
+      return (
+        seg(cb.input, 'seg-input', t.inputTokens) +
+        seg(cb.cacheRead, 'seg-cache-read', t.cacheRead) +
+        seg(cb.cacheWrite, 'seg-cache-creation', t.cacheCreation) +
+        seg(cb.output, 'seg-output', t.outputTokens)
+      );
+    };
 
-    // Generate chart bars for cost (default metric)
-    const maxCost = Math.max(...sortedData.map((d) => d.data.totalCost));
-    const maxHeight = 120; // Max height in pixels
+    const bars = sortedData
+      .map(({ date, data }) => {
+        const barHeight = maxCost > 0 ? (data.totalCost / maxCost) * maxHeight : 0;
+        const cb = data.costBreakdown;
+        return (
+          '<div class="hc-col" data-date="' + date + '">' +
+          '<div class="hc-barval">' + I18n.formatCurrency(data.totalCost) + '</div>' +
+          '<div class="chart-bar cost-bar cost-stacked clickable" style="height: ' + barHeight + 'px;" ' +
+          'data-cost="' + data.totalCost + '" ' +
+          'data-input="' + data.totalInputTokens + '" ' +
+          'data-output="' + data.totalOutputTokens + '" ' +
+          'data-cache-creation="' + data.totalCacheCreationTokens + '" ' +
+          'data-cache-read="' + data.totalCacheReadTokens + '" ' +
+          'data-messages="' + data.messageCount + '" ' +
+          'data-cost-input="' + cb.input + '" ' +
+          'data-cost-output="' + cb.output + '" ' +
+          'data-cost-cachewrite="' + cb.cacheWrite + '" ' +
+          'data-cost-cacheread="' + cb.cacheRead + '" ' +
+          'title="' + this.escapeHtml(this.formatDate(date)) + ': ' + I18n.formatCurrency(data.totalCost) + '">' +
+          costStack(data, barHeight) +
+          '</div>' +
+          '</div>'
+        );
+      })
+      .join('');
 
-    return `
-      <div class="chart-bars">
-        ${sortedData
-          .map(({ date, data }) => {
-            const height = maxCost > 0 ? (data.totalCost / maxCost) * maxHeight : 0;
-            return `
-            <div class="chart-bar-container" data-date="${date}">
-              <div class="chart-bar cost-bar clickable"
-                   style="height: ${height}px;"
-                   data-cost="${data.totalCost}"
-                   data-input="${data.totalInputTokens}"
-                   data-output="${data.totalOutputTokens}"
-                   data-cache-creation="${data.totalCacheCreationTokens}"
-                   data-cache-read="${data.totalCacheReadTokens}"
-                   data-messages="${data.messageCount}"
-                   title="${this.formatDate(date)}: ${I18n.formatCurrency(data.totalCost)}">
-              </div>
-              <div class="chart-label">${this.getShortDate(date)}</div>
-            </div>
-          `;
-          })
-          .join('')}
-      </div>
-    `;
+    const xlabels = sortedData
+      .map(({ date }) => '<div class="hc-xlabel">' + this.getShortDate(date) + '</div>')
+      .join('');
+
+    return (
+      '<div class="hc-wrap">' +
+      '<div class="hc-yaxis">' +
+      '<span class="hc-yval">' + I18n.formatCurrency(maxCost) + '</span>' +
+      '<span class="hc-yval">' + I18n.formatCurrency(maxCost / 2) + '</span>' +
+      '<span class="hc-yval">' + I18n.formatCurrency(0) + '</span>' +
+      '</div>' +
+      '<div class="hc-main"><div class="hc-scroll">' +
+      '<div class="hc-plot">' +
+      '<div class="hc-grid hc-grid-top"></div>' +
+      '<div class="hc-grid hc-grid-mid"></div>' +
+      '<div class="hc-bars">' + bars + '</div>' +
+      '</div>' +
+      '<div class="hc-xlabels">' + xlabels + '</div>' +
+      '</div></div>' +
+      '</div>'
+    );
   }
 
   /**
@@ -2161,6 +2179,20 @@ export class UsageWebviewProvider {
 
       .stack-seg {
         width: 100%;
+      }
+
+      /* Cost bar rendered as a stacked composition: no gradient fill, segments
+         stack from the bottom up. Segments ignore pointer events so a click
+         falls through to the parent .chart-bar.clickable (drill-down). */
+      .chart-bar.cost-stacked {
+        background: none;
+        display: flex;
+        flex-direction: column-reverse;
+        overflow: hidden;
+        padding: 0;
+      }
+      .chart-bar.cost-stacked .stack-seg {
+        pointer-events: none;
       }
 
       .seg-input {
@@ -2909,7 +2941,9 @@ document.addEventListener('click', function(event) {
     console.log("[DEBUG] Clickable chart bar clicked:", event.target);
 
     event.preventDefault();
-    const container = event.target.closest('.chart-bar-container');
+    // Daily/monthly charts now use .hc-col; the JS-rendered drill-downs still
+    // use .chart-bar-container — support both.
+    const container = event.target.closest('.hc-col') || event.target.closest('.chart-bar-container');
     if (container) {
       const date = container.dataset.date;
       if (date) {
@@ -3015,12 +3049,19 @@ function updateMainChart(metric, container) {
     // Update height
     bar.style.height = height + 'px';
 
-    // Update class - preserve clickable and selected states
-    const baseClass = 'chart-bar ' + getBarClass(metric);
     const hasClickable = bar.classList.contains('clickable');
     const hasSelected = bar.classList.contains('selected');
 
-    bar.className = baseClass;
+    // Cost metric on a chart that carries the cost breakdown (daily / monthly)
+    // renders a stacked composition; every other case is a single-colour bar.
+    const canStack = bar.dataset.costInput !== undefined;
+    if (metric === 'cost' && canStack) {
+      bar.className = 'chart-bar cost-bar cost-stacked';
+      bar.innerHTML = buildCostStack(bar, height);
+    } else {
+      bar.className = 'chart-bar ' + getBarClass(metric);
+      bar.innerHTML = '';
+    }
     if (hasClickable) {
       bar.classList.add('clickable');
     }
@@ -3079,6 +3120,22 @@ function getBarClass(metric) {
     'messages': 'messages-bar'
   };
   return mapping[metric] || 'cost-bar';
+}
+
+// Rebuild a cost bar's stacked composition (input / cache-read / cache-write /
+// output) from its data attributes. Matches the server-side renderMainCostChart
+// order and colours; segments are pointer-events:none so drill-down still works.
+function buildCostStack(bar, barHeight) {
+  const ci = parseFloat(bar.dataset.costInput) || 0;
+  const co = parseFloat(bar.dataset.costOutput) || 0;
+  const cw = parseFloat(bar.dataset.costCachewrite) || 0;
+  const cr = parseFloat(bar.dataset.costCacheread) || 0;
+  const total = ci + co + cw + cr;
+  function seg(v, cls) {
+    const h = total > 0 ? (v / total) * barHeight : 0;
+    return '<div class="stack-seg ' + cls + '" style="height: ' + h + 'px;"></div>';
+  }
+  return seg(ci, 'seg-input') + seg(cr, 'seg-cache-read') + seg(cw, 'seg-cache-creation') + seg(co, 'seg-output');
 }
 
 function formatValue(value, metric) {

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -919,9 +919,14 @@ export class UsageWebviewProvider {
     let rows = '';
     this.sessionBreakdown.forEach((s) => {
       const d = s.data;
+      // Conversation title (the name `claude --resume` shows); falls back to a
+      // short session id so same-project rows stay distinguishable either way.
+      const fullName = s.title || s.sessionId;
+      const displayName = fullName.length > 40 ? fullName.slice(0, 40) + '…' : fullName;
       rows +=
         '<tr class="sort-row"' +
         ' data-sort-time="' + s.startTime.getTime() + '"' +
+        ' data-sort-session="' + this.escapeHtml(fullName.toLowerCase()) + '"' +
         ' data-sort-project="' + this.escapeHtml((s.projectName || '').toLowerCase()) + '"' +
         ' data-sort-context="' + s.peakContextTokens + '"' +
         ' data-sort-duration="' + (s.endTime.getTime() - s.startTime.getTime()) + '"' +
@@ -929,6 +934,9 @@ export class UsageWebviewProvider {
         '>' +
         '<td class="date-cell" title="' + this.escapeHtml(s.sessionId) + '">' +
         this.escapeHtml(this.formatDateTime(s.startTime)) +
+        '</td>' +
+        '<td class="name-cell" title="' + this.escapeHtml(fullName + ' (' + s.sessionId + ')') + '">' +
+        this.escapeHtml(displayName) +
         '</td>' +
         this.renderProjectCell(s.projectName, s.projectPath) +
         '<td class="cost-cell">' + I18n.formatCurrency(d.totalCost) + '</td>' +
@@ -953,6 +961,7 @@ export class UsageWebviewProvider {
       '<table class="daily-table sortable-table">' +
       '<thead><tr>' +
       th('time', t.startTime) +
+      th('session', t.sessionTitle) +
       th('project', t.project) +
       th('cost', t.cost) +
       th('input', t.inputTokens) +
@@ -1536,14 +1545,14 @@ export class UsageWebviewProvider {
   }
 
   private getShortDate(dateString: string): string {
-    const date = new Date(dateString);
-    // Check if this is a month-only date (ends with -01)
+    // Parse 'YYYY-MM-DD' textually — new Date('YYYY-MM-DD') is UTC midnight,
+    // which shifts the displayed day back by one in negative-UTC timezones.
+    const [y, m, d] = dateString.split('-').map(Number);
+    // Month-only dates (first of month) label as YYYY/MM for monthly charts.
     if (dateString.endsWith('-01')) {
-      // Format as YYYY/MM for monthly data
-      return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}`;
+      return `${y}/${String(m).padStart(2, '0')}`;
     }
-    // Format as MM/DD for daily data
-    return `${date.getMonth() + 1}/${date.getDate()}`;
+    return `${m}/${d}`;
   }
 
   private formatDate(dateString: string): string {
@@ -3189,10 +3198,10 @@ function renderHourlyData(hourlyData, date) {
   html += '<button class="chart-tab" data-metric="messages">${I18n.t.popup.messages}</button>';
   html += '</div>';
 
-  html += '<div class="chart-container">';
+  // hc-wrap is self-contained (own Y-axis + scroll); a fixed-height
+  // chart-container wrapper would add a second scrollbar.
   html += '<div class="chart-content" id="hourly-chart-' + date + '">';
   html += renderHourlyChart(hourlyData, 'cost');
-  html += '</div>';
   html += '</div>';
 
   html += '<div class="daily-table-container"><table class="daily-table"><thead><tr>';
@@ -3240,10 +3249,9 @@ function renderDailyData(dailyData, monthDate) {
   html += '<button class="chart-tab" data-metric="messages">${I18n.t.popup.messages}</button>';
   html += '</div>';
 
-  html += '<div class="chart-container">';
+  // hc-wrap is self-contained (own Y-axis + scroll); no chart-container.
   html += '<div class="chart-content" id="daily-chart-' + monthDate + '">';
   html += renderDailyChart(dailyData, 'cost');
-  html += '</div>';
   html += '</div>';
 
   html += '<div class="daily-table-container"><table class="daily-table"><thead><tr>';
@@ -3352,14 +3360,19 @@ function griddedChart(items, metric, opts) {
 }
 
 function renderDailyChart(dailyData, metric) {
+  // Parse 'YYYY-MM-DD' textually: new Date('YYYY-MM-DD') is interpreted as
+  // UTC midnight, so getMonth()/getDate() shift back a day in negative-UTC
+  // timezones. String parts are timezone-proof.
+  function parts(dateStr) { return dateStr.split('-').map(Number); }
   return griddedChart(dailyData, metric, {
     keyName: 'date',
     clickable: false,
     // Show month/day (not just the day number) so the axis isn't ambiguous.
-    getLabel: function(it) { var d = new Date(it.date); return (d.getMonth() + 1) + '/' + d.getDate(); },
+    getLabel: function(it) { var p = parts(it.date); return p[1] + '/' + p[2]; },
     getTitle: function(it, v) {
-      var d = new Date(it.date);
-      return d.toLocaleDateString(__locale, __dateOpts()) + ': ' + formatValue(v, metric);
+      var p = parts(it.date);
+      var d = new Date(p[0], p[1] - 1, p[2]); // local-time construction
+      return d.toLocaleDateString(__locale) + ': ' + formatValue(v, metric);
     }
   });
 }


### PR DESCRIPTION
Patch release. All changes are backwards-compatible; new settings default to existing behaviour.

### Added
- **Claude Fable 5 / Mythos 5** pricing; `[1m]` long-context model ids resolve to base pricing (also fixes proxy configs like `deepseek-v4-pro[1m]`).
- **Stacked cost-composition charts** on Today (hourly), This-Month (daily) and All-Time (monthly) — each cost bar splits into input / output / cache-write / cache-read, with a Y-axis and reference lines.
- **Sessions tab "Session" column** showing the conversation title (sortable), so same-project sessions are distinguishable.

### Fixed
- **Quota stuck/stale or "only back after restart"**: expired windows roll to 0% and refetch; an expired in-memory token now re-reads `~/.claude/.credentials.json` (which Claude Code keeps refreshing) before our own refresh; 429 cool-down cut from 5 min to 60 s; gentler `/usage` cadence (60 s active / 120 s idle). Quota-after-reset adapted from #24 (@nickearnshaw).
- **Usage not showing on first VS Code open** (#26): status bar shows a loading state immediately; quota fetch is non-blocking.
- **"This project" undercounted / vanishing**: attribution keys off the session's home project dir (not the per-record cwd, which wanders mid-session); shown even at $0.
- **Message count** counts messages you actually typed (excludes API calls, `/command` echoes, interruption markers); token figures unchanged.
- **Per-metric chart Y-axis** updates on metric switch; sub-agent/workflow logs attribute to their parent session/project; activity-aware ~8 s refresh during active runs; drill-down double-scrollbar and negative-UTC date-label fixes; F5 `preLaunchTask` (#22, @nickearnshaw).

### Docs / project
- All language READMEs refreshed to v2 (zh-CN full); CHANGELOG link casing fixed; `CONTRIBUTING.md`, PR + issue templates; `cleanupPeriodDays` docs (#21) and webview loading guard (#20) from @nickearnshaw; `CLAUDE.md` updated.

Full detail: CHANGELOG `[2.0.2]`.

Known issue #27 (v2.0.1 dashboard won't open) — webview was substantially reworked here; asking the reporter to verify on v2.0.2. macOS Keychain support (#28) scheduled for v2.0.3.

Co-Authored-By: Claude <noreply@anthropic.com>