### PR TITLE
docs: detailed GitHub-form issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,33 +1,55 @@
-name: Bug report
-description: Something isn't working as expected
+name: 🐞 Bug report
+description: Report something that isn't working as expected — wrong numbers, a crash, or a UI glitch.
+title: "[Bug]: "
 labels: [bug]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the report! A few details make bugs much faster to fix.
-        Tip: the `Claude Code Usage: Show Diagnostic Logs` command prints
-        per-refresh stats (files scanned, records kept/rejected, models seen)
-        that are very helpful for usage/pricing issues.
+        Thanks for taking the time to file a bug. Token and cost numbers depend on details that vary a lot between setups (proxy, model vendor, OS), so the more of the fields below you can fill in, the faster this gets fixed.
+
+        💡 **Run this first:** the `Claude Code Usage: Show Diagnostic Logs` command (open the Command Palette and type "diagnostic") prints per-refresh stats — files scanned, records kept vs. rejected and why, and every model name it saw. That output resolves most usage and pricing reports on its own, so please paste it into the "Diagnostic logs" field below.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      description: A few quick checks that catch most already-known issues.
+      options:
+        - label: I searched [existing issues](../../issues?q=is%3Aissue) and didn't find a duplicate.
+          required: true
+        - label: I'm on the latest version of the extension, or I've written my version below.
+          required: true
+        - label: I read the README's Troubleshooting section (proxies, history retention, the AI advice feature).
+          required: false
   - type: textarea
     id: what-happened
     attributes:
       label: What happened?
-      description: What did you see, and what did you expect instead?
+      description: Describe the behaviour you actually saw. For wrong numbers, say what the extension showed and where (status bar, or which dashboard tab).
+      placeholder: The status bar showed $0.00 all day even though I ran several sessions.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect instead?
+      description: What should have happened?
     validations:
       required: true
   - type: textarea
     id: repro
     attributes:
       label: Steps to reproduce
+      description: The exact steps to trigger it. "I can't reliably reproduce it" is a valid answer — if so, describe when it tends to happen.
       placeholder: |
-        1. Open the dashboard …
-        2. Click …
+        1. Open the dashboard (Claude Code Usage: Open Dashboard)
+        2. Switch to the Sessions tab
         3. …
   - type: input
     id: ext-version
     attributes:
       label: Extension version
+      description: Marketplace page, or the Extensions sidebar entry for "Claude Code Usage".
       placeholder: e.g. 2.0.2
     validations:
       required: true
@@ -35,24 +57,39 @@ body:
     id: cc-version
     attributes:
       label: Claude Code version
+      description: Output of `claude --version`, if you use Claude Code.
       placeholder: e.g. 2.1.160
+  - type: input
+    id: vscode-version
+    attributes:
+      label: VS Code version
+      description: Help → About (Code → About on macOS).
+      placeholder: e.g. 1.96.0
   - type: dropdown
     id: os
     attributes:
-      label: OS
+      label: Operating system
       options:
         - Windows
         - macOS
         - Linux
-        - Other / Remote (SSH, devcontainer, WSL)
+        - Remote / containerised (SSH, devcontainer, WSL, Codespaces)
+    validations:
+      required: true
   - type: input
     id: proxy
     attributes:
-      label: Proxy / model setup (if relevant)
-      description: e.g. CC Switch + DeepSeek, native Anthropic, LiteLLM proxy…
+      label: Model / proxy setup
+      description: How Claude Code reaches a model. This strongly affects token and pricing data, so please be specific.
+      placeholder: e.g. native Anthropic · CC Switch + DeepSeek · LiteLLM proxy · Amazon Bedrock
   - type: textarea
     id: diagnostics
     attributes:
-      label: Diagnostic logs (optional)
-      description: Output of `Claude Code Usage: Show Diagnostic Logs`, if applicable.
+      label: Diagnostic logs
+      description: Paste the output of the diagnostic-logs command described above. This is the single most useful thing for usage and pricing bugs.
       render: text
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else?
+      description: Screenshots, your theme name (for rendering bugs), or any other context.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,10 @@
+# Templates keep reports actionable; the links below cover the common
+# "how do I…" cases. Blank issues stay enabled for now.
 blank_issues_enabled: true
+contact_links:
+  - name: 📖 Setup & troubleshooting (README)
+    url: https://github.com/jack21/ClaudeCodeUsage/blob/main/README.md
+    about: Configuration, how costs are calculated, proxies, history retention, and the AI advice feature — most setup questions are answered here.
+  - name: 🛍️ Marketplace Q&A
+    url: https://marketplace.visualstudio.com/items?itemName=GrowthJack.claude-code-usage&ssr=false#qna
+    about: General questions are also welcome on the VS Code Marketplace Q&A tab.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,27 +1,43 @@
-name: Feature request
-description: Suggest an idea or improvement
+name: 💡 Feature request
+description: Suggest a new capability or an improvement to an existing one.
+title: "[Feature]: "
 labels: [enhancement]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the idea! Heads-up on scope: this extension is intentionally
-        **Claude-only and lightweight**, focused on **token attribution** and
-        AI-assisted usage improvement. Multi-provider monitoring and full
-        billing reconciliation are out of scope. Ideas that sharpen token
-        insight or the advice experience are the best fit.
+        Thanks for the idea! One thing up front so we share the same picture of scope: this extension is intentionally **Claude-only, lightweight, and focused on token attribution and AI-assisted usage improvement**. Multi-provider dashboards and full billing reconciliation are deliberately out of scope. Requests that sharpen token insight, attribution, or the advice experience are the best fit and the most likely to ship.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched [existing issues](../../issues?q=is%3Aissue) and didn't find this request.
+          required: true
+        - label: This fits the project's scope (Claude-only, lightweight, token-attribution focused).
+          required: false
   - type: textarea
     id: problem
     attributes:
       label: What problem would this solve?
-      description: The user need behind the request, not just the solution.
+      description: Describe the underlying need, not just the solution. What are you trying to understand or do that the extension makes hard today?
+      placeholder: I can't tell which of my installed skills are actually worth the context they cost me.
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
       label: Proposed solution
+      description: What would you like the extension to do? A rough sketch is fine.
+    validations:
+      required: true
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives considered (optional)
+      label: Alternatives you've considered
+      description: Other approaches, existing workarounds, or other tools — and why they fall short.
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else?
+      description: Mock-ups, links, or examples that make the request concrete.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,21 +1,33 @@
-name: Question / Support
-description: Ask how something works or get help with setup
+name: ❓ Question / Support
+description: Ask how something works, or get help with setup.
+title: "[Question]: "
 labels: [question]
 body:
   - type: markdown
     attributes:
       value: |
-        Quick checks first: the [README](../../blob/main/README.md) covers
-        configuration, how costs are calculated, and troubleshooting (incl.
-        proxies, history retention, and the AI advice feature).
+        Happy to help! Two things answer most questions on the spot: the README's **Configuration** and **Troubleshooting** sections cover proxies, how costs are calculated, history retention, and the AI advice feature; and the `Claude Code Usage: Show Diagnostic Logs` command shows exactly what the extension is reading from your logs.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I checked the README (Configuration + Troubleshooting) and searched [existing issues](../../issues?q=is%3Aissue).
+          required: true
   - type: textarea
     id: question
     attributes:
       label: Your question
+      description: What would you like to know, or get working?
     validations:
       required: true
   - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Steps you've already taken and what you saw. Diagnostic-log output helps a lot for any "the numbers look wrong" question.
+  - type: textarea
     id: context
     attributes:
-      label: Context (optional)
-      description: Extension version, OS, proxy/model setup — whatever seems relevant.
+      label: Context
+      description: Extension version, VS Code version, OS, and your model/proxy setup (native Anthropic, CC Switch + DeepSeek, a proxy, …) — whatever seems relevant.


### PR DESCRIPTION
docs: detailed GitHub-form issue templates

## What
Rework the three issue templates into GitHub's issue-form style so reports arrive actionable:
- **Preflight checklists** — searched existing issues / on latest version / read troubleshooting.
- **Title prefixes** — `[Bug]:` / `[Feature]:` / `[Question]:` for scannable lists.
- **Bug report**: split "what happened" vs "what you expected", required Extension version + OS (dropdown), optional Claude Code / VS Code versions, model-proxy setup, and a dedicated **diagnostic-logs** field — the single most useful thing for usage/pricing bugs.
- **Feature request**: a short scope note (Claude-only, lightweight, token-attribution) up front, required problem + proposal.
- **Question**: points at the README first, then a focused question + what-was-tried.
- **config.yml**: blank issues stay enabled for now; adds two self-serve contact links (README, Marketplace Q&A).

## Why
Some low-signal reports lack the version, OS, and diagnostic output needed to act. Forms collect those without adding friction; the scope note heads off out-of-scope (multi-provider) asks.

## Notes
Docs-only, no behaviour change. All four files validate as YAML (bug=12, feature=6, question=5 body items; config blank=true).