### PR TITLE
ci: pin actions to SHAs + CODEOWNERS + drafter exclude-labels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners — automatically requested as reviewers on matching pull requests.
+# https://docs.github.com/articles/about-code-owners
+#
+# Order matters: the last matching pattern takes precedence.
+
+# Default owners for everything in the repo.
+* @Carl723000 @jack21

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,11 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 
+# Attribution-only merges (work that already shipped in an earlier release) carry
+# this label so they don't pollute the next release's notes.
+exclude-labels:
+  - 'skip-changelog'
+
 categories:
   - title: '✨ Features'
     labels: ['feature', 'enhancement']

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -73,7 +73,7 @@ jobs:
       # regenerate the body.
       - name: Attach .vsix to the GitHub Release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: claude-code-usage.vsix
           tag_name: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -29,6 +29,6 @@ jobs:
       contents: write   # create / update the draft release
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
## Summary
Supply-chain + workflow hardening, per @ildyria's suggestions in #32 / #33.

## Changes
- **Pin all GitHub Actions to commit SHAs** (`actions/checkout`, `actions/setup-node`, `softprops/action-gh-release`, `release-drafter/release-drafter`), each annotated with its `# vX`. A moving tag like `@v4` can be repointed by a compromised upstream; a pinned SHA cannot.
- **Add `.github/CODEOWNERS`** (`* @Carl723000 @jack21`) so PRs auto-request review.
- **`release-drafter.yml`: `exclude-labels: [skip-changelog]`** so attribution-only merges (work that already shipped in an earlier release) don't pollute the next release's notes.

## Type of change
- [x] Documentation / CI / chore

Co-authored with @ildyria 🙏
