### PR TITLE
Update release-drafter labels for version resolution

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -36,9 +36,9 @@ version-resolver:
   major:
     labels: ['breaking', 'major']
   minor:
-    labels: ['feature', 'enhancement', 'minor']
+    labels: ['minor']    # was ['feature', 'enhancement', 'minor']
   patch:
-    labels: ['fix', 'bug', 'docs', 'ci', 'chore', 'dependencies', 'patch']
+    labels: ['feature', 'enhancement', 'fix', 'bug', 'docs', 'ci', 'chore', 'dependencies', 'patch']
   default: patch
 
 # Apply a label from the branch name or a conventional-commit-style title prefix.


### PR DESCRIPTION
Move labels ('feature', 'enhancement') from minor to patch.

<!--
Thanks for contributing! A consistently-structured PR makes review fast —
and lets our (future) automated triage assist with first-pass analysis.
Keep the section headings; fill what applies, delete what doesn't.
-->

## Type of change

<!-- Keep one. A maintainer applies the matching label at merge; that label sets
     the release version bump. -->
- [ ] Bug fix (non-breaking) → `fix` (patch)
- [ ] New major or medium feature (non-breaking) → `feature` (minor)
- [ ] Breaking change (existing behaviour differs afterwards) → `breaking` (major)
- [ ] Documentation / CI / chore → `docs` / `ci` / `chore` (patch)