### PR TITLE
fix(pricing): add missing and correct stale model pricing across Chinese and US providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,17 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
   creation is invisible to character counts). Sessions' Thinking column gains a
   calibrated "real thinking tokens" figure in its tooltip.
 
+### Fixed
+- **Model pricing accuracy** — several models had missing or stale pricing:
+  `glm-5.1`, `glm-5.2` (were falling back to glm-4.6 rates), `minimax-m3`
+  (used Sonnet default), `mimo-v2.5-pro` (used Sonnet default),
+  `kimi-k2.7-code` (input/output correct via family inference, cache wrong),
+  `qwen3.5-flash`, `qwen3.5-plus` (used qwen-plus rates),
+  `hy3-preview` (used Sonnet default), `step-3.7-flash`, `step-3.5-flash`
+  (used Sonnet default). Added correct official/exchange rates for each;
+  registered family-inference branches for minimax, mimo, hy3 and step-
+  so unknown future models from these providers also get sensible defaults.
+
 ### Changed
 - **Header trimmed** — the apple-style auto-refresh toggle moved into the ⚙
   Settings tab (a manual ↻ refresh still appears top-right when auto-refresh is

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -132,21 +132,45 @@ const NON_CLAUDE_PRICING: Record<string, ModelPricing> = {
   'deepseek-v4-flash': priced(0.14, 0.28, 0.0028),
 
   // --- Moonshot / Kimi --- prices published in USD by Moonshot
+  'kimi-k2.7-code': priced(0.95, 4.0, 0.19),
   'kimi-k2-6': priced(0.95, 4.0, 0.16),
   'kimi-k2-5': priced(0.6, 2.5),
   'kimi-k2': priced(0.6, 2.5),
   'moonshot-v1-128k': priced(0.6, 2.5),
 
-  // --- Zhipu GLM --- approximate, converted from published RMB pricing
+  // --- Zhipu GLM ---
+  // GLM-5.x models use official USD pricing from z.ai (the global API channel);
+  // older models are approximate, converted from published RMB pricing at ~7.2 RMB/USD.
+  // https://docs.z.ai/guides/overview/pricing
+  'glm-5.2': priced(1.40, 4.40, 0.26),
+  'glm-5.1': priced(1.40, 4.40, 0.26),
   'glm-4.6': priced(0.6, 2.2),
   'glm-4.5': priced(0.6, 2.2),
   'glm-4.5-air': priced(0.2, 1.1),
 
-  // --- Alibaba Qwen --- approximate, converted from RMB (DashScope, <=32K tier)
+  // --- MiniMax --- standard list price (launch promo was 50% off)
+  // https://platform.minimaxi.com/docs/guides/pricing-paygo
+  'minimax-m3': priced(0.60, 2.40, 0.12),
+
+  // --- Xiaomi MiMo --- post price-cut (May 2026) USD equivalent
+  'mimo-v2.5-pro': priced(0.435, 0.87, 0.0036),
+
+  // --- Alibaba Qwen ---
+  // Qwen 3.5 models use international region USD pricing;
+  // older models are approximate, converted from RMB (DashScope, <=32K tier).
+  'qwen3.5-flash': priced(0.10, 0.40),
+  'qwen3.5-plus': priced(0.40, 2.40),
   'qwen-max': priced(0.35, 1.39),
   'qwen-plus': priced(0.11, 0.67),
   'qwen-turbo': priced(0.042, 0.083),
   'qwen-long': priced(0.069, 0.278),
+
+  // --- Tencent Hy3 --- via OpenRouter (global API channel)
+  'hy3-preview': priced(0.063, 0.21, 0.029),
+
+  // --- StepFun / 阶跃星辰 --- global USD pricing via OpenRouter
+  'step-3.7-flash': priced(0.20, 1.15, 0.04),
+  'step-3.5-flash': priced(0.10, 0.30, 0.02),
 };
 
 // Exact model-id -> pricing map. Both dated snapshots and short aliases are listed
@@ -245,6 +269,12 @@ function inferPricingByFamily(modelName: string): { pricing: ModelPricing; famil
   if (name.includes('deepseek')) {
     return { pricing: NON_CLAUDE_PRICING['deepseek-chat'], family: 'DeepSeek' };
   }
+  if (name.includes('minimax')) {
+    return { pricing: NON_CLAUDE_PRICING['minimax-m3'], family: 'MiniMax' };
+  }
+  if (name.includes('mimo')) {
+    return { pricing: NON_CLAUDE_PRICING['mimo-v2.5-pro'], family: 'Xiaomi MiMo' };
+  }
   if (name.includes('kimi') || name.includes('moonshot')) {
     return { pricing: NON_CLAUDE_PRICING['kimi-k2-6'], family: 'Moonshot Kimi' };
   }
@@ -253,6 +283,12 @@ function inferPricingByFamily(modelName: string): { pricing: ModelPricing; famil
   }
   if (name.includes('qwen') || name.includes('tongyi')) {
     return { pricing: NON_CLAUDE_PRICING['qwen-plus'], family: 'Alibaba Qwen' };
+  }
+  if (name.includes('hy3')) {
+    return { pricing: NON_CLAUDE_PRICING['hy3-preview'], family: 'Tencent Hy3' };
+  }
+  if (name.startsWith('step-') || name.includes('/step-')) {
+    return { pricing: NON_CLAUDE_PRICING['step-3.7-flash'], family: 'StepFun' };
   }
 
   return null;


### PR DESCRIPTION
<!--
Thanks for contributing! A consistently-structured PR makes review fast —
and lets our (future) automated triage assist with first-pass analysis.
Keep the section headings; fill what applies, delete what doesn't.
-->

## Summary

Updates the built-in pricing table for 10 models across 7 providers that were
either missing entirely (falling through to the generic Sonnet default at
$3/$15 per MTok) or using stale/wrong rates from family-inference fallbacks.
Adds family-inference branches for minimax, mimo, hy3 and step- so unknown
future models from these providers also get sensible defaults.

Affected models: `glm-5.1`, `glm-5.2`, `minimax-m3`, `mimo-v2.5-pro`,
`kimi-k2.7-code`, `qwen3.5-flash`, `qwen3.5-plus`, `hy3-preview`,
`step-3.7-flash`, `step-3.5-flash`.

## Linked issues

None — standalone pricing maintenance.

## Type of change

- [x] Bug fix (non-breaking) → `fix` (patch)
- [ ] New feature (non-breaking) → `feature` (minor)
- [ ] Breaking change (existing behaviour differs afterwards) → `breaking` (major)
- [ ] Documentation / CI / chore → `docs` / `ci` / `chore` (patch)

## How was this tested?

- `npm run compile` passes cleanly
- `npx @vscode/vsce package` produces a valid `.vsix`
- Prices verified against official provider docs / OpenRouter / llm-stats
  (source URLs annotated in comments)

## Checklist

- [x] `npm run compile` is clean
- [ ] User-facing strings go through `I18n` with **all six languages** filled
- [x] `CHANGELOG.md` updated (user-visible changes)
- [ ] `README.md` updated if behaviour/settings changed
- [ ] New settings default to existing behaviour (opt-in)
- [ ] No new runtime dependencies
