### PR TITLE
fix: refresh quota when the Claude account is switched (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,13 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
   calibrated "real thinking tokens" figure in its tooltip.
 
 ### Fixed
+- **Account switch now refreshes the quota** — switching Claude accounts no
+  longer leaves the status bar stuck on the previous account's usage until a
+  window reload. The OAuth credentials are re-read on every quota fetch (a
+  switched-in account's token is valid, so the old expiry-only re-read never
+  noticed it), and the credentials file is watched so the change is picked up
+  promptly instead of after a full cache interval. (Keychain-stored credentials
+  on macOS update on the next refresh tick.)
 - **Model pricing accuracy** — several models had missing or stale pricing:
   `glm-5.1`, `glm-5.2` (were falling back to glm-4.6 rates), `minimax-m3`
   (used Sonnet default), `mimo-v2.5-pro` (used Sonnet default),

--- a/src/claudeApiClient.ts
+++ b/src/claudeApiClient.ts
@@ -64,6 +64,14 @@ export class ClaudeApiClient {
     }
   }
 
+  /** Absolute path to the OAuth credentials file the client reads. Lets the
+   * extension watch it and refetch quota immediately on an account switch (#45).
+   * On macOS the credentials may instead live in the Keychain (no file to
+   * watch); that case still updates on the next quota refresh tick. */
+  getCredentialsPath(): string {
+    return this.credentialsPath;
+  }
+
   private loadCredentialsFromKeychain(): ClaudeCredentials | null {
     if (process.platform !== 'darwin') {
       return null;
@@ -145,7 +153,13 @@ export class ClaudeApiClient {
   }
 
   private async getValidCredentials(): Promise<ClaudeCredentials | null> {
-    let credentials = this.credentials || (await this.loadCredentials());
+    // Re-read from disk/keychain on every call so switching Claude accounts is
+    // honoured without a window reload. #45: a switched-in account has a *valid*
+    // (non-expired) token, so the expiry-only re-read below never noticed it and
+    // we kept serving the previous account's quota until the host restarted.
+    // loadCredentials refreshes this.credentials; fall back to the cached copy
+    // only if the fresh read transiently fails.
+    let credentials = (await this.loadCredentials()) || this.credentials;
     if (!credentials) {
       return null;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,10 @@ export class ClaudeCodeUsageExtension {
   private fileWatcher: fs.FSWatcher | undefined;
   private watchDebounceTimer: NodeJS.Timeout | undefined;
   private watchedDir: string | null = null;
+  // Watches ~/.claude/.credentials.json so an account switch is reflected
+  // promptly instead of after a full quota TTL (#45).
+  private credsWatcher: fs.FSWatcher | undefined;
+  private credsDebounceTimer: NodeJS.Timeout | undefined;
   private cache: {
     records: any[];
     contentAnalysis: ContentAnalysis | null;
@@ -90,6 +94,7 @@ export class ClaudeCodeUsageExtension {
     this.loadConfiguration();
     this.startAutoRefresh();
     this.refreshData().then(() => this.startFileWatching());
+    this.startCredentialsWatching();
     console.log('Claude Code Usage Extension: Initialization complete');
   }
 
@@ -492,6 +497,60 @@ export class ClaudeCodeUsageExtension {
     this.watchedDir = null;
   }
 
+  /**
+   * Watch the OAuth credentials file so switching Claude accounts updates the
+   * quota promptly. Without this, the quota stays on the previous account's
+   * numbers for up to a full TTL (120 s) — long enough to read as "stuck on the
+   * wrong account, only a window reload fixes it" (#45). On a change we drop the
+   * cached quota and refetch; the api client re-reads the new token. Watches the
+   * parent dir (the file is rewritten/replaced, which single-file watches miss)
+   * and filters by name. macOS Keychain-stored credentials have no file to
+   * watch — those still self-correct on the next refresh tick.
+   */
+  private startCredentialsWatching(): void {
+    const credsPath = this.apiClient.getCredentialsPath();
+    const dir = path.dirname(credsPath);
+    const name = path.basename(credsPath);
+    if (!fs.existsSync(dir)) {
+      return;
+    }
+    try {
+      this.credsWatcher = fs.watch(dir, (_event, filename) => {
+        if (filename && String(filename) !== name) {
+          return;
+        }
+        if (this.credsDebounceTimer) {
+          clearTimeout(this.credsDebounceTimer);
+        }
+        this.credsDebounceTimer = setTimeout(() => {
+          // The cached quota belongs to the previous token/account. Expire it so
+          // the next refresh bypasses the TTL and refetches with the new token.
+          // The api client's own 429 cool-down still protects the endpoint.
+          this.cache.usageLimitsLastUpdate = new Date(0);
+          this.refreshData();
+        }, 800);
+      });
+    } catch {
+      // Watching unsupported on this platform/filesystem — the refresh tick
+      // still picks up the new account within a TTL.
+    }
+  }
+
+  private stopCredentialsWatching(): void {
+    if (this.credsDebounceTimer) {
+      clearTimeout(this.credsDebounceTimer);
+      this.credsDebounceTimer = undefined;
+    }
+    if (this.credsWatcher) {
+      try {
+        this.credsWatcher.close();
+      } catch {
+        // Already closed.
+      }
+      this.credsWatcher = undefined;
+    }
+  }
+
   /** True when Claude Code has written a log line in the last 60 s. */
   private isActive(): boolean {
     return Date.now() - this.lastActivityAt < 60000;
@@ -742,6 +801,7 @@ export class ClaudeCodeUsageExtension {
       this.refreshTimer = undefined;
     }
     this.stopFileWatching();
+    this.stopCredentialsWatching();
     this.statusBar.dispose();
     this.webviewProvider.dispose();
   }


### PR DESCRIPTION
## What

Fixes #45 — after switching Claude accounts the status bar stayed on the previous account's quota until a `Developer: Reload Window`.

## Root cause

`ClaudeApiClient.getValidCredentials()` cached the OAuth credentials in memory and only re-read them from disk when the **token expired**. A switched-in account has a *valid* (non-expired) token, so that path never fired — the client kept calling `/usage` with the old account's token.

## Fix

- **Re-read credentials on every quota fetch** (file or macOS Keychain), falling back to the cached copy only if the fresh read transiently fails.
- **Watch `~/.claude/.credentials.json`** and expire the cached quota on change, so the switch is reflected within a refresh tick instead of after a full cache interval (≤120 s). Keychain-stored credentials (macOS) have no file to watch — those self-correct on the next tick.

Local usage **token counts** come from a shared local folder and were never affected — this only touches the account-level quota panel.

## Notes

- No new dependencies; follows the existing `fs.watch` pattern (projects-dir watcher) with disposal in `dispose()`.
- The api client's own 429 cool-down still protects the `/usage` endpoint when the cache is force-expired.
- `tsc` clean; `node --test` green (11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)