### PR TITLE
fix: recognize Claude Sonnet 5 as a 1M-context model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this fork compared to upstream
 [`ClaudeCodeUsage/ClaudeCodeUsage`](https://github.com/ClaudeCodeUsage/ClaudeCodeUsage) (last
 upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangelog.com).
 
+## [Unreleased]
+
+### Fixed
+- **Sonnet 5 context window** — `contextWindowFor()` only recognised the 1M
+  window via a "4.6+" pattern (e.g. `sonnet-4-6`), so `claude-sonnet-5` — which
+  has no `-4-` segment — fell through to the 200K legacy default. The dashboard
+  and status-bar context bar now correctly show a 1M window for Sonnet 5.
+
 ## [2.1.1] — Unreleased
 
 ### Added

--- a/src/dataLoader.ts
+++ b/src/dataLoader.ts
@@ -1202,11 +1202,15 @@ export class ClaudeDataLoader {
   }
 
   /** Model context-window size in tokens, plus whether it's a guess. Current
-   * Claude (Opus 4.6+, Sonnet 4.6+, Fable/Mythos 5) is 1M; Haiku and older
-   * Claude are 200K; a "[1m]" suffix forces 1M (the marker pricing.ts strips).
-   * A user override (>0) wins outright and is treated as exact. Unrecognised /
-   * proxied models fall back to 200K and are flagged `estimated` so the UI can
-   * mark the percentage as approximate. Verified vs the catalog 2026-06-13. */
+   * Claude (Opus 4.6+, Sonnet 4.6+, Sonnet 5+, Fable/Mythos 5) is 1M; Haiku
+   * and older Claude are 200K; a "[1m]" suffix forces 1M (the marker
+   * pricing.ts strips). A user override (>0) wins outright and is treated as
+   * exact. Unrecognised / proxied models fall back to 200K and are flagged
+   * `estimated` so the UI can mark the percentage as approximate.
+   * Sonnet 5 (`claude-sonnet-5`) verified 2026-07-01 —
+   * https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5
+   * ("1M tokens is both the default and the maximum; there is no smaller
+   * context variant"). */
   private static contextWindowFor(
     model: string,
     override: number = 0
@@ -1223,6 +1227,12 @@ export class ClaudeDataLoader {
     }
     // Opus 4.6+ and Sonnet 4.6+ are 1M; earlier 4.x and 3.x are 200K.
     if (/opus-4-(?:[6-9]|\d\d)\b/.test(m) || /sonnet-4-(?:[6-9]|\d\d)\b/.test(m)) {
+      return { tokens: 1_000_000, estimated: false };
+    }
+    // Sonnet 5.x+ (e.g. "claude-sonnet-5") has no "-4-" segment to match
+    // above, so check the major version directly. (Opus 5 doesn't exist yet —
+    // don't guess its window size here.)
+    if (/sonnet-(?:[5-9]|\d\d)(?:-|\b)/.test(m)) {
       return { tokens: 1_000_000, estimated: false };
     }
     if (/haiku/.test(m) || /opus|sonnet/.test(m)) {

--- a/src/test/dataLoader.test.ts
+++ b/src/test/dataLoader.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { ClaudeDataLoader } from '../dataLoader';
+import { ClaudeUsageRecord } from '../types';
+
+function record(model: string): ClaudeUsageRecord {
+  return {
+    timestamp: new Date().toISOString(),
+    message: {
+      model,
+      usage: { input_tokens: 1_000, output_tokens: 10 },
+    },
+  };
+}
+
+test('getCurrentContextInfo reports a 1M window for Sonnet 5', () => {
+  const info = ClaudeDataLoader.getCurrentContextInfo([record('claude-sonnet-5')]);
+  assert.ok(info, 'expected context info, got null');
+  assert.equal(info!.windowTokens, 1_000_000);
+  assert.equal(info!.estimated, false);
+});


### PR DESCRIPTION
## Summary

`contextWindowFor()` only recognized the 1M context window via a "4.6+"
version pattern (e.g. `sonnet-4-6`), so `claude-sonnet-5` — whose model ID
has no `-4-` segment — fell through to the legacy 200K default. This adds a
check for bare major-version-5+ Sonnet models, so the dashboard and
status-bar context bar correctly show a 1M window for Sonnet 5. Confirmed
against the [official docs](https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5):
"Claude Sonnet 5 supports the 1M token context window by default (1M tokens
is both the default and the maximum; there is no smaller context variant)."

## Linked issues

None.

## Type of change

- [x] Bug fix (non-breaking) → `fix` (patch)
- [ ] New feature (non-breaking) → `feature` (minor)
- [ ] Breaking change (existing behaviour differs afterwards) → `breaking` (major)
- [ ] Documentation / CI / chore → `docs` / `ci` / `chore` (patch)

## How was this tested?

- Added `src/test/dataLoader.test.ts` covering `getCurrentContextInfo` for
  `claude-sonnet-5`; confirmed it fails (200000) without the fix and passes
  (1000000) with it.
- `npm run compile` clean; `npm test` — all 25 tests pass.
- Manually checked the new regex against existing 4.x model IDs
  (`claude-opus-4-8`, `claude-opus-4-1-20250805`, `claude-sonnet-4-5-20250929`,
  `claude-haiku-4-5-20251001`, etc.) to confirm no regression to legacy
  classification.

## Checklist

- [x] `npm run compile` is clean
- [ ] User-facing strings go through `I18n` with **all six languages** filled
- [x] `CHANGELOG.md` updated (user-visible changes)
- [x] `README.md` updated if behaviour/settings changed — checked, no
  per-model context-window docs exist there to update
- [x] New settings default to existing behaviour (opt-in) — not applicable,
  no new settings
- [x] No new runtime dependencies