### PR TITLE
ci: autolabel PRs via release-drafter (pull_request_target)

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,19 +6,24 @@
 # maintainer reviews the draft and clicks "Publish release" when ready, which
 # creates the tag and triggers publish.yml.
 #
-# Why push-to-main only (no pull_request trigger): Release Drafter reads its
-# config from the *default* branch, and GitHub forces the default GITHUB_TOKEN
-# read-only for PRs opened from forks — so a pull_request autolabeler couldn't
-# label external contributions anyway. Maintainers set the version label when
-# they merge (the PR template shows the mapping; unlabeled defaults to patch).
-# To enable branch/title autolabeling for same-repo PRs later, add a
-# `pull_request_target` trigger plus `pull-requests: write`.
+# On PRs it also autolabels (title/branch -> version label; config in
+# .github/release-drafter.yml) so the draft's version + categories are right
+# without a manual label. It runs on `pull_request_target` (not `pull_request`)
+# so the token can write labels even on fork PRs — the autolabeler only reads the
+# PR title/branch, it never checks out or runs the PR's code. A maintainer can
+# still override the label before merge (unlabeled defaults to patch).
 
 name: Release Drafter
 
 on:
   push:
     branches: [main]
+  # Autolabel PRs (title/branch -> version label) so the draft's next version and
+  # categories are right without a manual label. `pull_request_target` so the
+  # token has write access even for fork PRs; the autolabeler only reads the PR
+  # title/branch and applies labels — it never checks out or runs the PR's code.
+  pull_request_target:
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -26,7 +31,8 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      contents: write   # create / update the draft release
+      contents: write        # create / update the draft release
+      pull-requests: write   # autolabeler applies labels to PRs
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6


### PR DESCRIPTION
The autolabeler config in `.github/release-drafter.yml` was ready but never ran — the workflow only triggered on push-to-main, so PRs were never auto-labelled and version labels were set by hand. Adds a `pull_request_target` trigger + `pull-requests: write` so title/branch labels are applied automatically (fork PRs too; the autolabeler reads title/branch only, never runs PR code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)