### PR TITLE
Enable @ccu-bot first-pass automation (issues + PRs)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,78 @@
+# Mention-driven assistant (V2.2 automation — Track 2, A1).
+#
+# Lets a MAINTAINER summon the assistant by writing "@ccu-bot ..." in an issue, an issue
+# comment, or a PR review/comment. Claude reads the repo (incl. CLAUDE.md /
+# ARCHITECTURE.md / CONTRIBUTING.md) and can open commits/PRs or reply.
+#
+# SAFE BY DEFAULT — this job is INERT until the owner opts in:
+#   1. Repo variable  AUTOMATION_ENABLED = 'true'   (Settings → Variables) — kill switch.
+#   2. Repo secret     ANTHROPIC_API_KEY             (Settings → Secrets).
+# With neither set, the `if:` gate is false and nothing runs / no budget is spent.
+#
+# THIRD-PARTY / NON-OFFICIAL MODELS: a Claude subscription (OAuth) can't be used
+# in CI — Actions needs a key. If you don't have an official Anthropic key, point
+# this at any Anthropic-format-compatible endpoint: set repo variable
+# ANTHROPIC_BASE_URL to that provider's base URL and store its key as the
+# ANTHROPIC_API_KEY secret (see the env: on the step below). Leave the variable
+# unset to use the official API.
+#
+# It also only responds to OWNER / MEMBER / COLLABORATOR authors, so a random
+# visitor can't spend the API budget by typing "@ccu-bot". Every other automation
+# piece (auto-triage A2, PR first-pass A3) is separate and still drafts-only.
+name: CCU Bot (mention)
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+# Least privilege: enough to comment / open a PR branch, nothing more.
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+concurrency:
+  group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  claude:
+    # Kill switch + "@ccu-bot" present + author is a maintainer.
+    if: |
+      vars.AUTOMATION_ENABLED == 'true' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@ccu-bot') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@ccu-bot') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@ccu-bot') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@ccu-bot') || contains(github.event.issue.title, '@ccu-bot')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        env:
+          # Empty by default → official API. Set the repo variable to use a
+          # third-party Anthropic-compatible endpoint (see header).
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Cap the agent loop so a single mention can't run away with the budget.
+          # Pin a model here if you want (e.g. --model claude-sonnet-4-5, or a
+          # third-party model id); the action otherwise picks a sensible default.
+          # Repo guidance (architecture, compile-clean, 7-language i18n, opt-in
+          # defaults) is read from CLAUDE.md / ARCHITECTURE.md — so it doesn't
+          # re-read the whole repo every time.
+          claude_args: "--max-turns 12"

--- a/.github/workflows/issue-first-pass.yml
+++ b/.github/workflows/issue-first-pass.yml
@@ -1,0 +1,68 @@
+# Auto first-pass reply on every NEW issue (V2.2 automation — Carl's opt-in).
+#
+# When an issue is opened, the assistant reads the project's architecture docs
+# and posts ONE helpful first-pass comment: what it understands, where in the
+# code/architecture it points, and either a suggested direction or a clarifying
+# question. Every comment is clearly labelled automated and ends with a
+# disclaimer that a maintainer follows up.
+#
+# SAFE BY DEFAULT — inert until the owner sets:
+#   1. Repo variable  AUTOMATION_ENABLED = 'true'   (kill switch)
+#   2. Repo secret     ANTHROPIC_API_KEY            (official or third-party key)
+# Optional: repo variable ANTHROPIC_BASE_URL for a third-party Anthropic-format
+# endpoint. Bot-authored issues are skipped (no loops).
+name: Issue first-pass (auto)
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read # read repo files to answer accurately (never guess)
+  issues: write # post the reply
+
+concurrency:
+  group: issue-first-pass-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  reply:
+    if: vars.AUTOMATION_ENABLED == 'true' && github.event.issue.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: First-pass reply
+        uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--max-turns 15"
+          prompt: |
+            You are the ClaudeCodeUsage repository assistant, running via Claude Code
+            (the model may be a third-party Anthropic-format model, so do not claim to
+            be Anthropic's Claude specifically).
+
+            A new issue was just opened (title/body in the event context). Post ONE
+            comment as a first-pass response. Rules:
+            - First read CLAUDE.md and CONTRIBUTING.md (and ARCHITECTURE.md if present)
+            for context.
+            - If those docs are NOT enough to answer accurately, READ the relevant
+              repository files to find the real answer. Never guess or invent an
+              answer — if you still can't determine it, say what's unclear and ask a
+              specific clarifying question instead of speculating.
+            - Be concrete and concise: what you understand the request to be, where in
+              the code/architecture it relates, and a suggested direction OR the
+              clarifying question needed. No filler, no AI-flavoured padding.
+            - Reply in the same language the issue author used.
+            - START the comment with: "🤖 Automated first-pass reply (via Claude Code)".
+            - END the comment with this disclaimer on its own line:
+              "_This is model-generated from the repository's architecture docs and
+              the issue description — not a final decision. A maintainer will review
+              and follow up._"
+            - Do not change labels, close the issue, or open PRs. Just the one comment.

--- a/.github/workflows/pr-first-pass.yml
+++ b/.github/workflows/pr-first-pass.yml
@@ -1,0 +1,66 @@
+# Auto first-pass review on every NEW pull request (V2.2 automation — opt-in).
+#
+# Uses pull_request_target so it has the token to comment, but it must NEVER run
+# the PR's code with that token. We check out the BASE repo (the default for
+# pull_request_target), read the PR diff via the API, and post ONE first-pass
+# review comment. Fork code is never executed here.
+#
+# SAFE BY DEFAULT — inert until the owner sets AUTOMATION_ENABLED='true' and the
+# ANTHROPIC_API_KEY secret (official or third-party). Bot-authored PRs skipped.
+name: PR first-pass (auto)
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-first-pass-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    # Skip bots and huge diffs (a > ~3000-line PR wants a human first).
+    if: vars.AUTOMATION_ENABLED == 'true' && github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      # Base repo only — do NOT check out or run the PR head with the token.
+      - name: Checkout base repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: First-pass review
+        uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--max-turns 15"
+          prompt: |
+            You are the ClaudeCodeUsage repository assistant, running via Claude Code
+            (the model may be a third-party Anthropic-format model; do not claim to be
+            Anthropic's Claude specifically).
+
+            A new pull request was opened. Do a first-pass review and post ONE comment.
+            SECURITY: never execute the PR's code. Read the PR DIFF via the GitHub API
+            and the repository's own files only.
+            Rules:
+            - First read CLAUDE.md and CONTRIBUTING.md (and ARCHITECTURE.md if present)
+            for the
+              conventions (compile-clean, node:test green, 7-language i18n, opt-in
+              defaults, CHANGELOG). If those aren't enough to judge accurately, read
+              the relevant base-repo files — never guess.
+            - Cover: correctness risks, convention/i18n/CHANGELOG gaps, and
+              merge-readiness. Be specific and concise; skip praise padding.
+            - If the diff is very large (> ~3000 lines) or you're unsure, say a human
+              should review rather than speculate.
+            - START with: "🤖 Automated first-pass review (via Claude Code)".
+            - END with: "_This is model-generated from the architecture docs and the
+              PR diff — not a merge decision. A maintainer reviews everything._"
+            - Do not approve, request changes as a formal review, merge, or push. One
+              comment only.

--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,10 @@ CLAUDE.local.md
 # samples. Curated excerpts may be hand-copied into the README, but the raw
 # reports must never be committed.
 
-# Local-only planning / architecture / dev-reference docs. The whole docs/
-# tree is the maintainer's private context pack — synced to a personal repo,
-# never shipped to the public repo. README / CHANGELOG live at the repo root.
-# (Re-track a specific doc later with `!docs/<name>` if it should become public.)
+# Local-only planning / dev-reference docs. The whole docs/ tree is the
+# maintainer's private context pack (product direction lives in
+# docs/ARCHITECTURE-private.md) — synced to a personal repo, never public.
+# README / CHANGELOG / ARCHITECTURE live at the repo root and ARE public:
+# ARCHITECTURE.md is the technical map the @ccu-bot automation + contributors
+# read (product strategy is kept out of it, in docs/ARCHITECTURE-private.md).
 docs/
-/ARCHITECTURE.md
-/ARCHITECTURE-zh-CN.md

--- a/ARCHITECTURE-zh-CN.md
+++ b/ARCHITECTURE-zh-CN.md
@@ -1,0 +1,134 @@
+# 架构说明
+
+> 本扩展的简明技术地图——它是什么、数据如何流动、以及那些"精确的" token / 成本
+> 数字是怎么算出来的。刻意写得简短：它是给贡献者（或自动化的 issue/PR 助手）
+> 读的参考，让他们**不必**重新通读 `src/`。如果你改变了某个模块的职责或数据
+> 流，请同步更新本文件。英文版见
+> [`ARCHITECTURE.md`](ARCHITECTURE.md)。
+
+## 它是什么（以及不是什么）
+
+**Claude Code Usage** 是一个 VS Code 扩展，通过读取 Claude Code 自己的本地日志，
+在状态栏和仪表盘 webview 中报告 Claude Code 的 token 用量与成本。它刻意保持：
+
+- **只服务 Claude**——围绕 Claude Code 的日志格式和 Anthropic 的 OAuth 额度构建。
+  （为方便 CC-Switch 用户，也给 DeepSeek 等做了定价，但 Claude 是核心。）
+- **轻量**——界面精简、无运行时依赖、次要视图默认折叠。
+- **聚焦 token 归因**——头部的核心数字是**精确的**，直接读自每次请求自带的用量
+  记账，而非估算。
+- 对 `~/.claude` **只读**——绝不写入 Claude Code 的数据。
+
+**范围之外**（用这张清单做 issue 初筛）：把多供应商/多厂商仪表盘当作一等功能；
+完整的账单/发票对账；写入或驱动 Claude Code；与用量无关的分析。能让 token 洞察、
+归因或建议体验更锋利的需求，才是合适的方向。
+
+## 模块地图（`src/`）
+
+| 模块 | 职责 |
+|---|---|
+| `extension.ts` | 激活、命令注册，以及刷新编排：一个"感知活跃度"、会自我重排的定时器（你活跃时更快、空闲时更缓），带 generation 守卫与合并去重，外加 `pauseDashboardRefresh`。配置经 `SettingsStore` 读取，启动时跑一次设置迁移，监听 workspace 文件夹切换（重取额度），并持有 `runOptimizer`（用量优化器往返）。把 loader + 状态栏 + webview + 额度客户端串起来。 |
+| `dataLoader.ts` | 数据管线。读取 `~/.claude/projects/**/*.jsonl`，解析/校验/去重记录，提取会话标题与用户提示标记，并完成全部聚合（`calculateUsageData` + 今日/本月/会话/项目/分组/分支等口径）。v2.1 还有：`getWorkflowBreakdown`（从 `subagents/` 日志识别多 agent 运行 + 临时批次）、`getUsageAttribution`（用量构成面板）、`getCurrentContextInfo` + `contextWindowFor`（按模型上下文窗口、取主线程记录、`estimated` 标记）、内容/校准分析（`windowDays` 可配）。逻辑量最大的一块。 |
+| `settings.ts` | **（v2.1）** 所有用户设置的单一真源：`SETTINGS` 目录（类型/默认/存储/分组）+ `SettingsStore`。核心三项（`language`、`dataDirectory`、`advice.apiKey`）留 VS Code 配置；其余进 `globalState`，由 dashboard 的 ⚙ 设置标签页编辑。`migrateOnce()` 把 2.1 前 `settings.json` 的值搬进存储。 |
+| `pricing.ts` | 按模型、按 token 的费率表（input / output / 缓存写 / 缓存读分别计价），模型家族推断，以及 `[1m]` 上下文后缀的剥离。`calculateCostBreakdown` 把一条用量记录变成四部分成本。 |
+| `statusBar.ts` | 三个状态栏条目：主条目（今日成本**或** token 量，`statusBarMetric`；三项全隐藏时退化为只剩图标的入口）、额度条目（5h / 每周，可选 `opus:NN%`）、实验性上下文窗口指示器（条形 + 明细 tooltip，窗口为猜测时标 `~`）。 |
+| `webview.ts` | 仪表盘：分页视图（今日、会话、项目、内容、分支、工作流、**⚙ 设置**）、AI 建议 + 用量优化器操作卡、图表与可排序表格。跨重渲染保留优化器状态，并跳过完全相同的重渲染。体量最大的文件——几乎所有 UI 都在这里。 |
+| `claudeApiClient.ts` | Anthropic OAuth 额度：读取 `~/.claude/.credentials.json`，刷新 token（先重读磁盘），从 `api.anthropic.com/api/oauth/usage` 拉取真实用量。走 `httpClient`（fetch → curl）；HTTP 429 冷却 60 秒。 |
+| `httpClient.ts` | **（v2.1）** 共享传输层：`requestViaFetch` 与 `requestViaCurl`（curl 的 `cwd` 钉到 home，避免切 workspace 后陈旧 cwd 触发 ENOENT）。curl 是 Anthropic TLS 指纹门 `403 "Request not allowed"` 的兜底。 |
+| `advisor.ts` | AI 建议 + **用量优化器**传输层：`callModel`（Anthropic `/v1/messages` 或 OpenAI chat-completions，带 curl 403 兜底）、`getUsageAdvice`，以及优化器纯函数 `buildOptimizerSystemPrompt` / `parseOptimizerOutput`。只支持 API（订阅分支留休眠）。需手动开启。 |
+| `adviceSummary.ts` | **（v2.1）** 构建发给建议模型的用量摘要——聚合 + 多 agent 运行 + 思考占比 + 归因 + 一段按窗口取的用户自己的 prompt 样本。 |
+| `adviceDemoSample.ts` | 在配置 key 之前展示的静态示例建议（六种语言全覆盖），让功能可被发现。 |
+| `i18n.ts` | 六种语言的字符串表（`en`、`de-DE`、`zh-TW`、`zh-CN`、`ja`、`ko`）+ `SETTINGS_I18N`（⚙ 设置面板每项的标签/帮助）与 `settingText()`。所有面向用户的字符串都经过这里。 |
+| `types.ts` | 共享接口（`ClaudeUsageRecord`、`UsageData`、`SessionUsage`、`SupportedLanguage`、`ExtensionConfig`、`ContextWindowInfo`、额度 + 归因 + 工作流类型……）。 |
+
+## 数据流
+
+```
+~/.claude/projects/<编码后的cwd>/<会话>.jsonl       （一个文件 = 一段对话）
+        │  逐行读取，对每行 JSON.parse
+        ▼
+校验（是用量记录吗？）─► 去重（messageId+requestId，保留 token 更高的那条）
+        │  给每条记录打上 会话 id + 项目（优先用真实 cwd）
+        ▼
+ClaudeUsageRecord[]  ──►  calculateUsageData()  ──►  UsageData
+        │                  （对 4 个 token 桶求和并各自计价）          │
+        │                                                             ├─► 状态栏（今日 + 额度）
+        └─ 会话标题、用户提示标记                                      └─► webview（各口径明细 + 图表）
+```
+
+额度是一条**独立**路径：`claudeApiClient` 调用 OAuth 用量接口，独立于本地日志地
+返回 5 小时 / 7 天 / 7 天 Opus 的用量占比（日志无从得知你套餐的上限，只有
+Anthropic 知道）。
+
+## token 与成本如何计算（精确，而非估算）
+
+JSONL 里每一行助手回复都带一个 `message.usage` 对象——这是 **Anthropic API 自己
+的 token 记账**，与 Anthropic 计费所依据的数字相同。扩展不去估算它们，而是读取、
+校验、去重、求和、计价：
+
+1. **校验**——只保留 `usage.input_tokens` 为数字的记录（真实 API 响应）；跳过
+   合成 / 报错 / `<synthetic>` 模型条目。
+2. **去重**——哈希 = `messageId + requestId`；冲突时保留 token 更高的那条（应对
+   某些代理会先记一行占位、再记真实数值的情况）。
+3. **求和**，把四个桶累加进总数：
+   - `input_tokens`——新鲜的 prompt，全价
+   - `cache_read_input_tokens`——从缓存命中的前缀，约为 input 价的 10%
+   - `cache_creation_input_tokens`——**写入**缓存的前缀（即"输入缓存（未命中）"
+     那根条），约为 input 价的 125%；在切换模型或间隔 >5 分钟后会飙升（prompt
+     缓存按模型隔离，TTL 约 5 分钟）
+   - `output_tokens`——生成内容，output 价
+4. **计价**——每个桶 × 其按模型的费率（`pricing.ts`）；成本 = 求和。
+
+产品中**唯一**的估算，是"内容"标签页里基于字符数的"什么在吃 token"拆解（以及计划
+中的 v2.2 模型匹配 / 缓存浪费功能）——它们始终标注为估算，绝不并入精确总数。
+"消息数"只统计用户手敲的 prompt，靠合成的零 token 标记记录实现，因此永不影响 token
+求和。
+
+## 模型核心功能的日志格式事实（2026-06-13 在磁盘上验证）
+
+JSONL 日志里*有*和*没有*什么——任何要推理运行、模型、effort 的功能的参考。当 Claude
+Code 格式漂移时，用 JSON 键探查重新验证（绝不要用子串 grep——见下方的坑）。
+
+- **运行配置（effort / thinking 预算）不被记录。** 任何用量行上都没有 `effort` /
+  `ultracode` / `maxThinking` / 推理预算字段。唯一的 mode 记录是一条 `type:"mode"` 行，
+  带 `permissionMode`（如 `"normal"`）。**我们无法得知一次运行用的是什么 effort 等级。**
+  ⇒ 唯一可靠的"动态工作流已启用"信号是 **`subagents/workflows/wf_<id>/` 目录的存在**，
+  而非 effort。普通 Task 工具扇出（无 `wf_` 目录）是"临时批次"，不是工作流。
+  - **坑：** 子串 grep `effort`/`ultracode` *看起来*命中了——但只在 prompt 正文和工具调用
+    日志里（包括本插件自己的命令一旦被记录）。解析 JSON 键；绝不为配置去 grep。
+- **skill / 插件归因是一等的。** 助手用量行带 `attributionSkill`（如
+  `"superpowers:executing-plans"`）和 `attributionPlugin`（如 `"superpowers"`）。它们是
+  权威的——优先用它们而非旧的 `<command-name>` / `Skill` tool_use 启发式，并用 skill/插件
+  自身行的*精确* `message.usage` 来加权。
+- **为什么原生 Claude 的"工作流"在工作流 tab 里看起来缺失。** Claude 子代理日志*确实*
+  存在（某些 `subagents/` 目录下有 haiku/opus）。但当原生 Claude 运行用 ultracode 时，
+  昂贵的 **Opus/Fable 编排留在主会话日志里**，只有便宜的 **haiku** 子代理（或没有）写
+  `agent-*.jsonl`。一个重度 Fable/Opus 的主线程可能**根本没有 `subagents/` 目录**。工作流
+  tab 按*子代理文件*分组，所以它显示便宜模型、漏掉主线程成本——这正是 v2.1-PartII 要修的
+  （关联运行的编排主会话并显示其成本/模型）。**通则：** *昂贵*模型通常是主线程编排者；
+  子代理文件偏便宜。永远不要只凭子代理文件推断"我主要用哪个模型"。
+- **较新的字段（Claude Code ≥ 2.1）** 值得知道：顶层 `entrypoint`（如 `claude-vscode`）、
+  `permissionMode`、`version`、`context_management`；行 `type`：`mode`、`last-prompt`
+  （逐字的最后一条用户 prompt）、`queue-operation`、`file-history-snapshot`、`attachment`、
+  `system`（hook 摘要）；`message.usage` 上：`service_tier`、`iterations`、`speed`、
+  `inference_geo`、`cache_creation`（对象）。总量（`input/output/cache_*`）仍然精确。
+
+## 关键不变量（别破坏它们）
+
+- 对 `~/.claude` **只读**（唯一的写是 `claudeApiClient` 刷新 `advice.apiKey` 的 token；绝不动用户日志）。
+- 所有面向用户的字符串都要走 `i18n.ts`、**六种语言齐全**；设置面板的标签/帮助走 `SETTINGS_I18N`（英文回退到目录）。
+- **设置统一走 `SettingsStore`，不要散读。** 只有核心三项（`language`、`dataDirectory`、`advice.apiKey`）声明在 `package.json` / VS Code 配置；其余在 `globalState`，必须经 store 读（`config.get` 找不到）。加一个设置 = `settings.ts` 目录里一条 +（其 `SETTINGS_I18N` 行）。
+- 新设置**默认维持现有行为**（opt-in）；实验性/近似功能默认关闭（上下文指示器、用量优化器）。
+- **不新增运行时依赖。** 对外调用（额度、建议/优化器）走 `httpClient` 的 fetch→curl 403 兜底；spawn `curl` 时 `cwd: os.homedir()`。
+- 精确总数与标注过的估算，永不混在一起。
+- 建议/优化器**只**发送用量摘要 / 粘贴的草稿——绝不发送用户的文件。
+
+## 刷新模型
+
+仪表盘 / 状态栏靠 `extension.ts` 里一个感知活跃度的循环保持最新：一个自我重排的
+定时器，你活跃时间隔缩短、空闲时拉长，由 `refreshGen` generation 计数器与合并去重
+守护，避免重叠刷新堆叠。对 `~/.claude/projects` 的文件监听（可关闭）带来约 1.5 秒
+延迟；定时器是兜底。面板打开查看时，`pauseDashboardRefresh` 会冻结更新。
+
+## 发布
+
+TypeScript strict、干净编译（`node ./node_modules/typescript/bin/tsc -p ./`——F5/调试任务用它而非 `npm`，绕开 Windows 的 `npm.ps1` 执行策略拦截）、`node:test` 全绿。仓库在组织 **`ClaudeCodeUsage/ClaudeCodeUsage`**，`main` 有分支保护（PR + `test` 检查）。流程（Release Drafter，v2.0.3 搭好）：贡献者提 PR；维护者带版本标签（`patch`/`minor`/`major`，默认 patch）**squash-merge**——这就是每个 PR 的全部操作；草稿 Release 自动攒好分类发布说明；点 **Publish** 打 `v*` 标签，`publish.yml` 盖好 `package.json`、用 `@vscode/vsce` 打包，发到 VS Code Marketplace + Open VSX 并附 `.vsix`。跨 fork PR 的署名由 squash-merge 保住；个别手动重落用 `git merge -s ours` 把贡献者提交留作已合并祖先。关 issue 的 PR 用 `Closes #N`。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,190 @@
+# Architecture
+
+> A concise technical map of this extension — what it is, how data flows, and
+> how the exact token/cost numbers are produced. Kept deliberately short: it is
+> the reference a contributor (or an automated issue/PR helper) reads *instead
+> of* re-reading `src/`. If you change a module's role or the data flow, update
+> this file. A Simplified-Chinese version lives in
+> [`ARCHITECTURE-zh-CN.md`](ARCHITECTURE-zh-CN.md).
+
+## What it is (and isn't)
+
+**Claude Code Usage** is a VS Code extension that reports Claude Code token
+usage and cost — in the status bar and a dashboard webview — by reading Claude
+Code's own local logs. It is deliberately:
+
+- **Claude-only** — built around Claude Code's log format and Anthropic's OAuth
+  quota. (DeepSeek etc. are priced as a courtesy for CC-Switch users, but Claude
+  is the focus.)
+- **Lightweight** — minimal UI, no runtime dependencies, secondary views
+  collapsed by default.
+- **Token-attribution focused** — the headline numbers are *exact*, read from
+  each request's own usage accounting, not estimated.
+- **Read-only** over `~/.claude` — it never writes to Claude Code's data.
+
+**Out of scope** (use this list to triage requests): multi-provider/vendor
+dashboards as a first-class feature; full billing/invoice reconciliation;
+writing to or driving Claude Code; non-usage analytics. Requests that sharpen
+token insight, attribution, or the advice experience are the right fit.
+
+## Module map (`src/`)
+
+| Module | Role |
+|---|---|
+| `extension.ts` | Activation, command registration, and the refresh orchestration: an activity-aware, self-rescheduling timer (faster while you're active, calmer when idle) with a generation guard and coalescing, plus `pauseDashboardRefresh`. Reads config through `SettingsStore`, runs the settings migration once, listens for workspace-folder changes (re-fetches quota), and owns `runOptimizer` (the Usage Optimizer round-trip). Wires loader + status bar + webview + quota client together. |
+| `dataLoader.ts` | The data pipeline. Reads `~/.claude/projects/**/*.jsonl`, parses/validates/dedups records, harvests session titles and user-prompt markers, and aggregates everything (`calculateUsageData` + today/month/session/project/group/branch breakdowns). Also v2.1: `getWorkflowBreakdown` (multi-agent runs from `subagents/` logs + ad-hoc batches), `getUsageAttribution` (the "what's contributing" panel), `getCurrentContextInfo` + `contextWindowFor` (per-model context window, main-thread record, `estimated` flag), and the content/calibration analysis (`windowDays` configurable). The largest piece of logic. |
+| `settings.ts` | **(v2.1)** Single source of truth for every user setting: the `SETTINGS` catalog (type/default/storage/group) + `SettingsStore`. A small core (`language`, `dataDirectory`, `advice.apiKey`) lives in VS Code config; the rest in `globalState`, edited from the dashboard's ⚙ Settings tab. `migrateOnce()` copies pre-2.1 `settings.json` values into the store. |
+| `pricing.ts` | Per-model, per-token rate table (separate input / output / cache-write / cache-read rates), model-family inference, and `[1m]`-context-suffix stripping. `calculateCostBreakdown` turns a usage record into a four-part cost. |
+| `statusBar.ts` | Three status-bar items: the primary (today's cost **or** token count, `statusBarMetric`; icon-only entry fallback when all three are hidden), the quota item (5h / weekly, opt-in `opus:NN%`), and the experimental context-window indicator (bar + breakdown tooltip, `~` for guessed windows). |
+| `webview.ts` | The dashboard: tabbed views (today, sessions, projects, content, branches, workflows, **⚙ settings**), the AI-advice + Usage-Optimizer action cards, charts and sortable tables. Holds optimizer state across re-renders and skips identical re-renders. By far the biggest file — almost all UI lives here. |
+| `claudeApiClient.ts` | Anthropic OAuth quota: reads `~/.claude/.credentials.json`, refreshes the token (re-reading disk first), and fetches real utilisation from `api.anthropic.com/api/oauth/usage`. Uses `httpClient` (fetch → curl). 60s cool-down on HTTP 429. |
+| `httpClient.ts` | **(v2.1)** Shared transport: `requestViaFetch` and `requestViaCurl` (curl `cwd` pinned to home so a stale workspace cwd can't ENOENT it). curl is the fallback for Anthropic's TLS-fingerprint `403 "Request not allowed"` gate. |
+| `advisor.ts` | The AI-advice + **Usage Optimizer** transport: `callModel` (Anthropic `/v1/messages` or OpenAI chat-completions, with the curl 403 fallback), `getUsageAdvice`, and the optimizer's pure helpers `buildOptimizerSystemPrompt` / `parseOptimizerOutput`. API-only (a dormant subscription branch remains). Opt-in. |
+| `adviceSummary.ts` | **(v2.1)** Builds the usage digest sent to the advice model — aggregates + multi-agent runs + thinking share + attribution + a windowed sample of the user's own prompts. |
+| `adviceDemoSample.ts` | Static sample advice (all seven languages) shown before a key is configured, so the feature is discoverable. |
+| `i18n.ts` | The string table for seven languages (`en`, `de-DE`, `zh-TW`, `zh-CN`, `ja`, `ko`, `pt-BR`) + `SETTINGS_I18N` (per-setting label/help for the ⚙ Settings panel) and `settingText()`. Every user-facing string goes through here. |
+| `types.ts` | Shared interfaces (`ClaudeUsageRecord`, `UsageData`, `SessionUsage`, `CostlyMessage`, `SupportedLanguage`, `ExtensionConfig`, `ContextWindowInfo`, quota + attribution + workflow types, …). |
+
+### V2.2 additions (pure, unit-tested modules)
+| Module | Role |
+|---|---|
+| `shareCard.ts` | Pure share-card logic: `buildShareCardData` (privacy redaction — the type carries no prompt/path/id field), `ShareSections`/`DEFAULT_SECTIONS`, `selectShareBadge`, `prettyModelName`, `rangeLabel`, `shareCardFilename`. |
+| `shareCardSvg.ts` | Self-contained SVG renderer for the share card (no DOM/fonts/network). `SHARE_CARD_THEMES` (claudeCream / claudeClassic / auroraDark) + `resolveShareCardTheme`; `BADGE_COPY`. Landscape 1200×680. |
+| `heatmap.ts` / `heatmapSvg.ts` | GitHub-contribution-style token heatmap logic + SVG (`buildContributionGrid`, `renderHeatmapSvg`). Exported/published to a GitHub profile repo (`extension.publishHeatmapToGitHub`, built-in GitHub auth + Contents API). |
+| `dateKeys.ts` | Timezone-consistent day/month bucketing (`dayKeyInZone`/`monthKeyInZone`) so dashboard buckets match the configured zone. |
+| `promptDedup.ts` | Dedups api_error retry re-logs so message counts aren't inflated. |
+| `quotaFormat.ts` | Pure status-bar quota text formatter (kept clean; reset detail lives in the tooltip). |
+| `dataContribution.ts` | Opt-in, OFF-by-default SCAFFOLD for future authorized cross-user signals (e.g. cache-TTL by tier). No endpoint / no-op; the Observation type has no identifying field. |
+
+New data-layer methods on `dataLoader.ts`: `getCostliestMessages` (top-N single
+turns + prompt + skill + cost split + gap + prev-model, for the Content tab's
+"costliest messages"), `estimateCacheTtl` (hit-rate-by-gap-bin → warm-window
+estimate; measured ~60 min), `buildShareInput` (range today/week/last30/month/
+year/`month:YYYY-MM` + scope all/project/session). Efficiency insights
+(cost/tokens per message, realised cache savings, "Cache warmth"), thinking-share
+"hidden" handling (Fable 5 / Opus omit CoT text), and timezone = full UTC-offset
+coverage are all V2.2. CI: `@ccu-bot` first-pass automation (`claude.yml`,
+`issue-first-pass.yml`, `pr-first-pass.yml`) — INERT unless `AUTOMATION_ENABLED`;
+official or third-party (`ANTHROPIC_BASE_URL`) key; reads this file.
+
+## Data flow
+
+```
+~/.claude/projects/<encoded-cwd>/<session>.jsonl     (one file = one conversation)
+        │  read line-by-line, JSON.parse each line
+        ▼
+validate (is it a usage record?) ─► dedup (messageId+requestId, keep higher tokens)
+        │  tag each record with session id + project (real cwd preferred)
+        ▼
+ClaudeUsageRecord[]  ──►  calculateUsageData()  ──►  UsageData
+        │                   (sum the 4 token buckets, price each)        │
+        │                                                                ├─► status bar (today + quota)
+        └─ session titles, user-prompt markers                           └─► webview (breakdowns + charts)
+```
+
+Quota is a **separate** path: `claudeApiClient` calls the OAuth usage endpoint
+and returns five-hour / seven-day / seven-day-opus utilisation independently of
+the local logs (the logs cannot know your plan's limits; only Anthropic does).
+
+## How tokens & cost are computed (exact, not estimated)
+
+Each assistant-response line in the JSONL carries a `message.usage` object — the
+**Anthropic API's own token accounting**, the same counts Anthropic bills on.
+The extension does not estimate these; it reads, validates, dedups, sums, and
+prices them:
+
+1. **Validate** — keep only records whose `usage.input_tokens` is a number (real
+   API responses); skip synthetic/error/`<synthetic>` model entries.
+2. **Dedup** — hash = `messageId + requestId`; on collision keep the
+   higher-token copy (handles proxies that log a placeholder line first, then
+   the real values).
+3. **Sum** the four buckets into the totals:
+   - `input_tokens` — fresh prompt, full price
+   - `cache_read_input_tokens` — prefix served from cache, ~10% of input price
+   - `cache_creation_input_tokens` — prefix *written* to cache (the
+     "Input Cache (Miss)" bar), ~125% of input price; spikes on a model switch
+     or after an idle gap past the cache TTL (the prompt cache is per-model; the
+     TTL is platform-side — MEASURED at ~60 min in practice, not the assumed
+     5 min — and `estimateCacheTtl` infers it from the user's own turns)
+   - `output_tokens` — generated, output price
+4. **Price** — each bucket × its per-model rate (`pricing.ts`); cost = the sum.
+
+The **only** estimates in the product are the Content tab's character-based
+"what's consuming tokens" breakdown (and the planned v2.2 model-fit /
+cache-waste features) — always labelled as estimates and never folded into the
+exact totals. "Messages" counts user-typed prompts only, via synthetic
+zero-token marker records, so it never affects token sums.
+
+## Log-format facts for model-core features (verified on disk 2026-06-13)
+
+What the JSONL logs *do* and *don't* contain — the reference for any feature
+that reasons about runs, models, or effort. Re-verify with a JSON-key probe
+(never a substring grep — see the trap below) when Claude Code's format drifts.
+
+- **Run config (effort / thinking budget) is NOT logged.** There is no
+  `effort` / `ultracode` / `maxThinking` / reasoning-budget field on any usage
+  line. The only mode record is a `type:"mode"` line carrying `permissionMode`
+  (e.g. `"normal"`). **We cannot tell what effort level a run used.** ⇒ the only
+  reliable "dynamic-workflow engaged" signal is the **presence of a
+  `subagents/workflows/wf_<id>/` directory**, not effort. A plain Task-tool
+  fan-out (no `wf_` dir) is an "ad-hoc batch", not a workflow.
+  - **Trap:** a substring grep for `effort`/`ultracode` *appears* to hit — but
+    only inside prompt text and tool-call logs (including this extension's own
+    commands once they're logged). Parse JSON keys; never grep for config.
+- **Skill / plugin attribution IS first-class.** Assistant usage lines carry
+  `attributionSkill` (e.g. `"superpowers:executing-plans"`) and
+  `attributionPlugin` (e.g. `"superpowers"`). These are authoritative — prefer
+  them over the older `<command-name>` / `Skill` tool_use heuristic, and
+  cost-weight a skill/plugin by the *exact* `message.usage` of its own lines.
+- **Why native-Claude "workflows" look missing from the Workflows tab.** Claude
+  sub-agent logs *do* exist (haiku/opus appear under some `subagents/` dirs).
+  But when a native-Claude run uses ultracode, the expensive **Opus/Fable
+  orchestration stays in the main session log**, and only cheap **haiku**
+  sub-agents (or none) write `agent-*.jsonl`. A heavy Fable/Opus main thread can
+  produce **no `subagents/` dir at all**. The Workflows tab groups *sub-agent
+  files*, so it shows the cheap models and misses the main-thread cost — hence
+  the v2.1-PartII fix to associate a run's orchestrating main session and surface
+  its cost/models. **General principle:** the *expensive* model is usually the
+  main-thread orchestrator; sub-agent files skew cheap. Never infer "which model
+  I mainly use" from sub-agent files alone.
+- **Newer fields (Claude Code ≥ 2.1)** worth knowing: top-level `entrypoint`
+  (e.g. `claude-vscode`), `permissionMode`, `version`, `context_management`; line
+  `type`s `mode`, `last-prompt` (verbatim last user prompt), `queue-operation`,
+  `file-history-snapshot`, `attachment`, `system` (hook summaries); and on
+  `message.usage`: `service_tier`, `iterations`, `speed`, `inference_geo`,
+  `cache_creation` (object). Totals (`input/output/cache_*`) remain exact.
+
+## Key invariants (don't break these)
+
+- **Read-only** over `~/.claude` (the one write is `advice.apiKey` token refresh in `claudeApiClient`; never touch user logs).
+- Every user-facing string goes through `i18n.ts` in **all seven languages**; settings-panel labels/help go through `SETTINGS_I18N` (English fallback from the catalog).
+- **Settings live in `SettingsStore`, not scattered reads.** Only the core trio (`language`, `dataDirectory`, `advice.apiKey`) is declared in `package.json` / VS Code config; everything else is `globalState` and must be read via the store (so `config.get` won't find it). Adding a setting = one catalog entry in `settings.ts` (+ its `SETTINGS_I18N` rows).
+- New settings **default to existing behaviour** (opt-in); experimental/approximate features default OFF (context indicator, Usage Optimizer).
+- **No new runtime dependencies.** External calls (quota, advice/optimizer) go through `httpClient` with the fetch→curl 403 fallback; spawn `curl` with `cwd: os.homedir()`.
+- Exact totals and labelled estimates never mix.
+- Advice/Optimizer send **only** the usage digest / the pasted draft — never the user's files.
+
+## Refresh model
+
+The dashboard/status bar stay current via an activity-aware loop in
+`extension.ts`: a self-rescheduling timer whose interval shortens when you're
+active and lengthens when idle, guarded by a `refreshGen` generation counter and
+coalescing so overlapping refreshes can't stack. File-watching of
+`~/.claude/projects` (opt-out) gives ~1.5s latency; an interval is the fallback.
+`pauseDashboardRefresh` freezes updates while the panel is open for inspection.
+
+## Release
+
+TypeScript strict, clean compile (`node ./node_modules/typescript/bin/tsc -p ./`
+— the F5/debug task uses this, not `npm`, to dodge the Windows `npm.ps1`
+execution-policy block), green `node:test`. The repo lives at the org
+**`ClaudeCodeUsage/ClaudeCodeUsage`**; `main` is branch-protected (PR + `test`
+check). Flow (Release Drafter, set up in v2.0.3): contributors open PRs; the
+maintainer **squash-merges** with a version label (`patch`/`minor`/`major`,
+default patch) — that's the whole per-PR action; a **draft GitHub Release**
+auto-accumulates categorised notes; clicking **Publish** tags `v*` and
+`publish.yml` stamps `package.json`, packages with `@vscode/vsce`, and ships to
+the VS Code Marketplace + Open VSX with the `.vsix` attached. A cross-fork PR's
+attribution is preserved by squash-merge; the rare manual re-apply uses
+`git merge -s ours` to keep the contributor's commits as merged ancestors.
+Issue-closing PRs use `Closes #N`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,30 @@ tags:
 Because changes ship by **merging** your PR — not by re-applying it — your commit
 authorship and the PR's *merged* status are preserved.
 
+## Automated first-pass replies (@ccu-bot)
+
+New issues and pull requests may get an **automated first-pass reply** from
+`@ccu-bot` — an assistant run via [Claude Code](https://github.com/anthropics/claude-code-action)
+that reads the project's architecture docs to help triage faster.
+
+What to expect and its limits:
+
+- Every automated comment is clearly labelled **"🤖 Automated first-pass reply
+  (via Claude Code)"** and ends with a note that it is model-generated and a
+  **maintainer reviews everything** — it is not a decision.
+- It reads `ARCHITECTURE.md`, `CLAUDE.md`, `CONTRIBUTING.md` and, when those
+  aren't enough, the relevant repository files. It should **ask rather than
+  guess** when unsure — if it ever states something wrong, just correct it; a
+  maintainer will confirm.
+- It only **comments**. It does not label, close, merge, approve, or push. For
+  PRs it reads the diff via the API and **never runs your code**.
+- You can summon it in a comment with `@ccu-bot ...` (maintainer-gated).
+- The whole thing is **off unless the maintainer enables it** (a repo variable
+  kill switch), and the model may be a third-party Anthropic-compatible one, so
+  "Claude Code" refers to the tooling, not necessarily Anthropic's Claude.
+
+Treat its replies as a helpful starting point, not authority.
+
 ## Code of conduct
 
 Be kind and constructive. We're all here to make a useful tool.


### PR DESCRIPTION
Adds only the **automation-enablement slice** so the @ccu-bot first-pass can be tested without merging the rest of V2.2.

### What's in it
- `claude.yml` — maintainer `@ccu-bot` mention agent.
- `issue-first-pass.yml` — one first-pass comment on each **new issue**.
- `pr-first-pass.yml` — one first-pass review on each **new PR** (base checkout only; reads the diff via API, **never runs PR code**).
- Publishes the technical `ARCHITECTURE.md` (+ zh-CN) so the bot has a real map; product strategy stays private.
- CONTRIBUTING: a short section describing `@ccu-bot` and its limits.

### Safe by default
Every job's `if:` requires **both** the repo variable `AUTOMATION_ENABLED == 'true'` **and** the `ANTHROPIC_API_KEY` secret. Supports a third-party Anthropic-format endpoint via `ANTHROPIC_BASE_URL`. Replies are labelled automated + disclaimed ("a maintainer reviews everything"); bot-authored items skipped; concurrency + timeout + max-turns.

Merge this, then a test issue will trigger the first-pass so we can see the model's output. The rest of V2.2 lands in its own PR later.