### PR TITLE
fix(ci): add id-token: write to @ccu-bot first-pass workflows

### DIFF
--- a/.github/workflows/issue-first-pass.yml
+++ b/.github/workflows/issue-first-pass.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: read # read repo files to answer accurately (never guess)
   issues: write # post the reply
+  id-token: write # claude-code-action mints its GitHub token via OIDC
 
 concurrency:
   group: issue-first-pass-${{ github.event.issue.number }}

--- a/.github/workflows/pr-first-pass.yml
+++ b/.github/workflows/pr-first-pass.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write # claude-code-action mints its GitHub token via OIDC
 
 concurrency:
   group: pr-first-pass-${{ github.event.pull_request.number }}


### PR DESCRIPTION
The issue/PR first-pass runs failed with `Could not fetch an OIDC token. Did you remember to add id-token: write?`. `claude-code-action@v1` mints its GitHub token via OIDC and needs `id-token: write` (the mention workflow already had it). This adds it to issue-first-pass.yml + pr-first-pass.yml. Merge, then a new test issue should get a reply.