### PR TITLE
fix(ci): @ccu-bot uses github.token (no Claude GitHub App needed)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,6 +69,9 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Use the workflow token so no Claude GitHub App install is needed
+          # (we drive a third-party model; the app is only Anthropic's GitHub auth).
+          github_token: ${{ github.token }}
           # Cap the agent loop so a single mention can't run away with the budget.
           # Pin a model here if you want (e.g. --model claude-sonnet-4-5, or a
           # third-party model id); the action otherwise picks a sensible default.

--- a/.github/workflows/issue-first-pass.yml
+++ b/.github/workflows/issue-first-pass.yml
@@ -43,6 +43,9 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Use the workflow token so no Claude GitHub App install is needed
+          # (we drive a third-party model; the app is only Anthropic's GitHub auth).
+          github_token: ${{ github.token }}
           claude_args: "--max-turns 15"
           prompt: |
             You are the ClaudeCodeUsage repository assistant, running via Claude Code

--- a/.github/workflows/pr-first-pass.yml
+++ b/.github/workflows/pr-first-pass.yml
@@ -41,6 +41,9 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Use the workflow token so no Claude GitHub App install is needed
+          # (we drive a third-party model; the app is only Anthropic's GitHub auth).
+          github_token: ${{ github.token }}
           claude_args: "--max-turns 15"
           prompt: |
             You are the ClaudeCodeUsage repository assistant, running via Claude Code


### PR DESCRIPTION
Runs failed with "Claude Code is not installed on this repository" — the action defaults to a Claude GitHub App token via OIDC. We use a third-party model (DeepSeek), so passing `github_token: ${{ github.token }}` makes it use the workflow token to comment instead — no Anthropic app install needed. Applied to all 3 workflows.