### PR TITLE
Drop unused @types/glob to clear vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "test": "npm run compile && node --test out/test/*.test.js"
   },
   "devDependencies": {
-    "@types/glob": "^9.0.0",
     "@types/node": "24.0.15",
     "@types/vscode": "^1.74.0",
     "typescript": "^5.8.3"


### PR DESCRIPTION
## Summary

Removes the `@types/glob` devDependency, the sole source of three high-severity `npm audit`
advisories. It was an unused, deprecated stub, so deleting it prunes the entire vulnerable
transitive chain with no code or behaviour change.

* @types/glob was unused and deprecated (glob ships its own types)
* it transitively pulled glob → minimatch → brace-expansion
* removing it clears 3 high-severity advisories; audit now clean
* never shipped to users (devDependency; node_modules excluded from the vsix)

## Linked issues

None (standalone).

## Type of change

- [x] Documentation / CI / chore → `chore` (patch)

## How was this tested?

`npm ci` on `main` (before) vs this branch (after):

**Before**
```
➜ npm ci
npm warn deprecated @types/glob@9.0.0: This is a stub types definition. glob provides its own type definitions, so you do not need this installed.

added 45 packages, and audited 46 packages in 782ms

13 packages are looking for funding
  run `npm fund` for details

3 high severity vulnerabilities

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
```

**After**
```
➜ npm ci

added 4 packages, and audited 5 packages in 411ms

found 0 vulnerabilities
```

Also verified on this branch:
* `npm run compile` — clean
* `npm test` — 25/25 pass (full suite, clean build)

## Checklist

- [x] `npm run compile` is clean
- [ ] User-facing strings go through `I18n` with **all six languages** filled  (N/A: no user-facing strings touched)
- [ ] `CHANGELOG.md` updated (user-visible changes)  (N/A: dev-only dependency, not user-visible; can add a Security/Maintenance note if preferred)
- [ ] `README.md` updated if behaviour/settings changed  (N/A: no behaviour/settings change)
- [ ] New settings default to existing behaviour (opt-in)  (N/A: no new settings)
- [x] No new runtime dependencies (this PR removes one)
