### PR TITLE
feat(ci): two-tier first-pass bot with controlled repo-file escalation

### DIFF
--- a/.github/scripts/first-pass.mjs
+++ b/.github/scripts/first-pass.mjs
@@ -1,20 +1,39 @@
-// Controlled first-pass reply for @ccu-bot — ONE model call, then post ONE
-// comment. Deliberately NOT an autonomous agent: it uses no tools and never
-// runs anything from the issue/PR, so a malicious public issue cannot steer it
-// into misusing the token or leaking the key (prompt-injection safe). It only
-// reads the project docs (+ PR diff), asks the model once, and comments.
+// Controlled first-pass reply for issues / PRs — still NOT an autonomous agent.
+// It uses no agent tools and never runs anything from the issue/PR, so a
+// malicious public issue cannot steer it into misusing the token or leaking the
+// key (prompt-injection safe). Flow:
+//
+//   Tier 1  cheap model (CCU_BOT_MODEL, default deepseek-v4-flash) answers from
+//           the project docs (+ PR diff). It also returns a <control> signal.
+//   Tier 2  if it says it can't answer from the docs, escalate to a stronger
+//           model (CCU_BOT_MODEL_PRO, default deepseek-v4-pro) with thinking on,
+//           and let it name a few repo source files — WHICH THE SCRIPT reads and
+//           validates (no tool call, no traversal, size-capped). It re-answers.
+//   Tier 3  if it still can't, its reply politely asks for the missing info /
+//           logs and (when fields are missing) suggests the issue template.
+//
+// Then post ONE comment. The model only ever READS repo-relative text files the
+// script hand-picks; it never executes anything.
 //
 // Env in: GH_TOKEN, REPO (owner/name), EVENT_KIND (issue|pr), ITEM_NUMBER,
 // ITEM_TITLE, ITEM_BODY, DIFF_FILE (pr only), ANTHROPIC_API_KEY,
-// ANTHROPIC_BASE_URL (third-party OK), CCU_BOT_MODEL.
+// ANTHROPIC_BASE_URL (third-party OK), CCU_BOT_MODEL, CCU_BOT_MODEL_PRO.
 
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
 
 const env = process.env;
 const base = (env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com').replace(/\/$/, '');
 const model = env.CCU_BOT_MODEL || 'deepseek-v4-flash';
+const modelPro = env.CCU_BOT_MODEL_PRO || 'deepseek-v4-pro';
 const isPr = env.EVENT_KIND === 'pr';
 const num = env.ITEM_NUMBER;
+const kind = isPr ? 'review' : 'reply';
+
+const fail = (msg) => {
+  console.error(msg);
+  process.exit(1);
+};
 
 const readDoc = (path, max = 12000) => {
   try {
@@ -32,56 +51,162 @@ if (isPr && env.DIFF_FILE) {
   diff = readDoc(env.DIFF_FILE, 40000);
 }
 
-const kind = isPr ? 'review' : 'reply';
-const system = [
-  'You are the ClaudeCodeUsage repository assistant, replying via Claude Code tooling.',
-  'The underlying model may be a third-party Anthropic-format model, so do not claim to be Anthropic\'s Claude specifically.',
-  `Write ONE concise, concrete first-pass ${kind} for the ${isPr ? 'pull request' : 'issue'} below.`,
-  isPr
-    ? '- Cover correctness risks, convention/i18n/CHANGELOG gaps, and merge-readiness, grounded in the diff + docs.'
-    : '- Say what you understand the request to be, where in the architecture it relates, and a concrete suggested direction OR a specific clarifying question.',
-  `- Answer ONLY from the provided project docs${isPr ? ' and diff' : ''}. If they are insufficient, say exactly what is unclear and ask a specific question — NEVER guess or invent facts about the code.`,
-  '- Reply in the SAME language the author wrote in. Be specific and concise; no filler, no AI-flavoured padding.',
-  `- Start the comment with: "🤖 Automated first-pass ${kind} (via Claude Code)".`,
-  `- End with, on its own line: "_This is model-generated from the repository docs and the ${isPr ? 'PR diff' : 'issue'} — not a final decision. A maintainer reviews everything._"`,
-].join('\n');
-
-const userText = isPr
-  ? `PR #${num}: ${env.ITEM_TITLE}\n\n${env.ITEM_BODY || '(no description)'}\n\n--- DIFF (truncated) ---\n${diff}\n\n--- PROJECT DOCS ---\n${docs}`
-  : `Issue #${num}: ${env.ITEM_TITLE}\n\n${env.ITEM_BODY || '(no body)'}\n\n--- PROJECT DOCS ---\n${docs}`;
-
-const fail = (msg) => {
-  console.error(msg);
-  process.exit(1);
+// --- Safe repo-file reader: only repo-relative text files, no traversal ------
+const REPO_ROOT = resolve(process.cwd());
+const ALLOWED_EXT = /\.(ts|tsx|js|jsx|mjs|cjs|json|md|ya?ml|txt)$/i;
+const readRepoFiles = (wanted) => {
+  const out = [];
+  let budget = 60000; // total bytes across all requested files
+  for (const raw of (wanted || []).slice(0, 6)) {
+    const rel = String(raw || '').trim().replace(/^\.?\//, '');
+    if (!rel || rel.includes('..') || rel.includes('\0') || !ALLOWED_EXT.test(rel)) {
+      continue;
+    }
+    const abs = resolve(REPO_ROOT, rel);
+    if (abs !== REPO_ROOT && !abs.startsWith(REPO_ROOT + sep)) {
+      continue; // escaped the repo root
+    }
+    try {
+      if (!existsSync(abs) || !statSync(abs).isFile()) {
+        continue;
+      }
+      const body = readFileSync(abs, 'utf8').slice(0, Math.min(16000, budget));
+      budget -= body.length;
+      out.push(`# ${rel}\n${body}`);
+      if (budget <= 0) {
+        break;
+      }
+    } catch {
+      /* skip unreadable */
+    }
+  }
+  return out.join('\n\n');
 };
 
-// 1) One model call (Anthropic Messages format; works against a third-party
-//    Anthropic-compatible endpoint via ANTHROPIC_BASE_URL).
-let reply = '';
-try {
-  const res = await fetch(`${base}/v1/messages`, {
+// --- System prompt -----------------------------------------------------------
+const buildSystem = (final) =>
+  [
+    'You are the ClaudeCodeUsage repository assistant, replying via Claude Code tooling.',
+    "The underlying model may be a third-party Anthropic-format model, so do not claim to be Anthropic's Claude specifically.",
+    `Write ONE concise, concrete first-pass ${kind} for the ${isPr ? 'pull request' : 'issue'} below.`,
+    isPr
+      ? '- Focus on correctness risks, convention/i18n/CHANGELOG gaps, and merge-readiness, grounded in the diff + docs.'
+      : '- Identify the request, where in the architecture it relates, and a concrete direction or a specific clarifying question.',
+    '- Answer ONLY from the provided material (docs, diff, and any source files supplied). NEVER guess or invent code facts.',
+    '- Reply in the SAME language the author wrote in. Be specific; no filler, no AI-flavoured padding.',
+    '',
+    'Format your reply markdown in this order so a human can skim it:',
+    `- First line: "🤖 Automated first-pass ${kind} (via Claude Code)".`,
+    '- Then **TL;DR / 结论**: one or two sentences — the answer or the current status.',
+    '- Then **分析 / Analysis**: briefly why / what is happening / where it sits.',
+    '- Then **建议 / Suggested next step(s)**: a concrete direction, a specific question, or exactly what info is needed.',
+    `- Last line, on its own: "_This is model-generated from the repository docs and the ${isPr ? 'PR diff' : 'issue'} — not a final decision. A maintainer reviews everything._"`,
+    '',
+    final
+      ? '- If you STILL cannot determine the answer from everything provided, say so plainly in the TL;DR, then ask for the specific missing information (repro steps, logs, versions, config). If the issue omits obvious details, politely suggest filling out the issue template next time.'
+      : '- If the docs/diff are insufficient, you may request source files (see the control block); do not pad the answer with guesses.',
+    '',
+    'Before the reply, emit exactly one control line and nothing before it:',
+    '<control>{"answerable": <true if you can answer concretely from the material provided, false if you need to see source code>, "want_files": [<up to 6 repo-relative source paths that would let you answer>]}</control>',
+    'Then the reply, wrapped as:',
+    '<reply>',
+    '...markdown reply...',
+    '</reply>',
+  ].join('\n');
+
+const buildUser = (extraFiles) =>
+  (isPr
+    ? `PR #${num}: ${env.ITEM_TITLE}\n\n${env.ITEM_BODY || '(no description)'}\n\n--- DIFF (truncated) ---\n${diff}`
+    : `Issue #${num}: ${env.ITEM_TITLE}\n\n${env.ITEM_BODY || '(no body)'}`) +
+  `\n\n--- PROJECT DOCS ---\n${docs}` +
+  (extraFiles ? `\n\n--- REPO SOURCE FILES (read-only) ---\n${extraFiles}` : '');
+
+// --- One model call (Anthropic Messages format; third-party-compatible) ------
+const askModel = async (useModel, system, userText, think) => {
+  const body = {
+    model: useModel,
+    max_tokens: 1400,
+    system,
+    messages: [{ role: 'user', content: userText }],
+  };
+  if (think) {
+    body.thinking = { type: 'enabled', budget_tokens: 6000 };
+  }
+  let res = await fetch(`${base}/v1/messages`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
       'x-api-key': env.ANTHROPIC_API_KEY,
       'anthropic-version': '2023-06-01',
     },
-    body: JSON.stringify({
-      model,
-      max_tokens: 1200,
-      system,
-      messages: [{ role: 'user', content: userText }],
-    }),
+    body: JSON.stringify(body),
   });
+  if (!res.ok && think) {
+    // Endpoint may not accept the thinking param — retry once without it.
+    const errTxt = await res.text();
+    if (/think|budget|adaptive|reason/i.test(errTxt)) {
+      delete body.thinking;
+      res = await fetch(`${base}/v1/messages`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': env.ANTHROPIC_API_KEY,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify(body),
+      });
+    } else {
+      fail(`Model API error ${res.status}: ${errTxt.slice(0, 500)}`);
+    }
+  }
   if (!res.ok) {
     fail(`Model API error ${res.status}: ${(await res.text()).slice(0, 500)}`);
   }
   const data = await res.json();
-  reply = (data.content || [])
+  return (data.content || [])
     .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
     .map((b) => b.text)
     .join('')
     .trim();
+};
+
+const tag = (text, name) => {
+  const m = text.match(new RegExp(`<${name}>([\\s\\S]*?)<\\/${name}>`, 'i'));
+  return m ? m[1].trim() : null;
+};
+const parse = (raw) => {
+  const replyBody = tag(raw, 'reply') || raw.replace(/<control>[\s\S]*?<\/control>/i, '').trim();
+  let control = { answerable: true, want_files: [] };
+  const ctl = tag(raw, 'control');
+  if (ctl) {
+    try {
+      const j = JSON.parse(ctl);
+      control = {
+        answerable: j.answerable !== false,
+        want_files: Array.isArray(j.want_files) ? j.want_files : [],
+      };
+    } catch {
+      /* keep default (treat as answerable → no escalation) */
+    }
+  }
+  return { reply: replyBody, ...control };
+};
+
+let reply = '';
+try {
+  // Tier 1: cheap model, docs only.
+  const first = parse(await askModel(model, buildSystem(false), buildUser('')));
+  reply = first.reply;
+
+  // Tier 2/3: escalate to the stronger model with thinking + the source files
+  // it named (read & validated by the script), and take its final reply.
+  if (!first.answerable) {
+    const extra = readRepoFiles(first.want_files);
+    const second = parse(await askModel(modelPro, buildSystem(true), buildUser(extra), true));
+    if (second.reply) {
+      reply = second.reply;
+    }
+  }
 } catch (e) {
   fail(`Model call failed: ${e.message}`);
 }
@@ -89,7 +214,7 @@ if (!reply) {
   fail('Empty model reply.');
 }
 
-// 2) Post ONE comment via the GitHub API (issues + PRs share this endpoint).
+// Post ONE comment via the GitHub API (issues + PRs share this endpoint).
 const [owner, repo] = (env.REPO || '/').split('/');
 try {
   const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues/${num}/comments`, {

--- a/.github/workflows/issue-first-pass.yml
+++ b/.github/workflows/issue-first-pass.yml
@@ -7,7 +7,9 @@
 #   AUTOMATION_ENABLED = 'true'   (repo variable, kill switch)
 #   ANTHROPIC_API_KEY             (repo secret — official or third-party key)
 # Optional repo variables: ANTHROPIC_BASE_URL (third-party Anthropic-format
-# endpoint), CCU_BOT_MODEL (defaults to deepseek-v4-flash).
+# endpoint), CCU_BOT_MODEL (cheap tier, default deepseek-v4-flash),
+# CCU_BOT_MODEL_PRO (escalation tier used when the cheap tier can't answer from
+# the docs, default deepseek-v4-pro).
 name: Issue first-pass (auto)
 
 on:
@@ -44,4 +46,5 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           CCU_BOT_MODEL: ${{ vars.CCU_BOT_MODEL }}
+          CCU_BOT_MODEL_PRO: ${{ vars.CCU_BOT_MODEL_PRO }}
         run: node .github/scripts/first-pass.mjs

--- a/.github/workflows/pr-first-pass.yml
+++ b/.github/workflows/pr-first-pass.yml
@@ -4,7 +4,8 @@
 # API, asks the model once, and posts one comment. No tools → injection-safe.
 #
 # INERT until AUTOMATION_ENABLED = 'true' + the ANTHROPIC_API_KEY secret.
-# Optional repo vars: ANTHROPIC_BASE_URL, CCU_BOT_MODEL (default deepseek-v4-flash).
+# Optional repo vars: ANTHROPIC_BASE_URL, CCU_BOT_MODEL (cheap tier, default
+# deepseek-v4-flash), CCU_BOT_MODEL_PRO (escalation tier, default deepseek-v4-pro).
 name: PR first-pass (auto)
 
 on:
@@ -48,4 +49,5 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
           CCU_BOT_MODEL: ${{ vars.CCU_BOT_MODEL }}
+          CCU_BOT_MODEL_PRO: ${{ vars.CCU_BOT_MODEL_PRO }}
         run: node .github/scripts/first-pass.mjs


### PR DESCRIPTION
Builds on #64.

## What
When the cheap first-pass model (`CCU_BOT_MODEL`, default `deepseek-v4-flash`) reports it can't answer from the project docs alone, escalate:

1. **Tier 2** — a stronger model (new `CCU_BOT_MODEL_PRO`, default `deepseek-v4-pro`) with thinking on, and it may **name** a few repo source files to consult.
2. The **script** reads those files — repo-relative text files only, no `..`, size-capped (16KB/file, 60KB total), must resolve inside the repo root. The model never runs a tool; it only names paths the script validates and reads. Same injection-safe property as #64, plus a controlled retrieval step.
3. **Tier 3** — if it still can't answer, the reply asks for the specific missing info/logs and suggests the issue template.

Every reply is now standardized into a skimmable shape: **TL;DR/结论 → analysis → suggested next steps**.

## Safety
- No autonomous agent, no agent tools — still one (or two) plain model calls + one comment.
- File reads are script-driven and path-guarded (verified: `../../etc/passwd`, `/etc/hosts`, NUL-injection all rejected).
- `thinking` param is best-effort: the script retries once without it if a third-party endpoint rejects it, so it stays portable.
- Still **inert** until `AUTOMATION_ENABLED='true'` + `ANTHROPIC_API_KEY`.

## New repo variable
- `CCU_BOT_MODEL_PRO` (optional, Settings → Variables) — escalation model, defaults to `deepseek-v4-pro`.