### PR TITLE
fix(ci): skip auto-review on maintainer PRs; empty reply is a no-op

### DIFF
--- a/.github/scripts/first-pass.mjs
+++ b/.github/scripts/first-pass.mjs
@@ -211,7 +211,11 @@ try {
   fail(`Model call failed: ${e.message}`);
 }
 if (!reply) {
-  fail('Empty model reply.');
+  // A blank reply is a soft no-op, not a failure: posting nothing is fine, and
+  // we don't want a red ✗ check on the PR/issue just because the model returned
+  // no text (e.g. a huge or self-referential diff).
+  console.warn('Empty model reply — nothing to post.');
+  process.exit(0);
 }
 
 // Post ONE comment via the GitHub API (issues + PRs share this endpoint).

--- a/.github/workflows/pr-first-pass.yml
+++ b/.github/workflows/pr-first-pass.yml
@@ -22,7 +22,13 @@ concurrency:
 
 jobs:
   review:
-    if: vars.AUTOMATION_ENABLED == 'true' && github.event.pull_request.user.type != 'Bot'
+    # Skip PRs from maintainers (OWNER / MEMBER / COLLABORATOR): their PRs are
+    # usually finished work that doesn't need an auto first-pass — the review is
+    # for external contributors. Also skip bot-authored PRs.
+    if: >-
+      vars.AUTOMATION_ENABLED == 'true'
+      && github.event.pull_request.user.type != 'Bot'
+      && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:


### PR DESCRIPTION
Follow-up to #66.

**Problem** (seen on #66): the PR first-pass fires on *any* non-bot PR — including a maintainer's own finished PR — and on #66 it failed with `Empty model reply` on the large self-referential diff, leaving a red ✗ check for no reason.

**Fixes**
1. **Skip maintainer PRs** — the `if:` now also requires the PR author to *not* be `OWNER` / `MEMBER` / `COLLABORATOR`. Auto first-pass is for external-contributor PRs; a maintainer's completed PR doesn't need it. (Issue auto-triage is unchanged.)
2. **Empty reply → no-op** — `first-pass.mjs` now exits 0 (with a warning) instead of failing when the model returns no text, so a benign blank response doesn't mark the check failed.

No behaviour change when enabled for a contributor PR with a normal reply.