### PR TITLE
fix: stop treating daily dates on the 1st as month-only labels

### DIFF
--- a/src/webview.ts
+++ b/src/webview.ts
@@ -1416,7 +1416,7 @@ export class UsageWebviewProvider {
         ${this.renderCompositionChart(
           [...this.dailyDataForAllTime]
             .sort((a, b) => a.date.localeCompare(b.date))
-            .map((d) => ({ label: this.getShortDate(d.date), data: d.data, key: d.date }))
+            .map((d) => ({ label: this.getShortDate(d.date, true), data: d.data, key: d.date }))
         )}
 
         <div class="daily-table-container">
@@ -1439,7 +1439,7 @@ export class UsageWebviewProvider {
                 .map(
                   ({ date, data }) => `
                 <tr class="daily-row" data-date="${date}">
-                  <td class="date-cell">${this.formatDate(date)}</td>
+                  <td class="date-cell">${this.formatDate(date, true)}</td>
                   <td class="cost-cell">${I18n.formatCurrency(data.totalCost)}</td>
                   <td class="number-cell">${I18n.formatNumber(data.totalInputTokens)}</td>
                   <td class="number-cell">${I18n.formatNumber(data.totalOutputTokens)}</td>
@@ -3228,7 +3228,7 @@ export class UsageWebviewProvider {
 
   private renderAllTimeChart(): string {
     const sortedData = [...this.dailyDataForAllTime].sort((a, b) => a.date.localeCompare(b.date));
-    return this.renderMainCostChart(sortedData);
+    return this.renderMainCostChart(sortedData, true);
   }
 
   /**
@@ -3266,7 +3266,7 @@ export class UsageWebviewProvider {
     );
   }
 
-  private renderMainCostChart(sortedData: { date: string; data: UsageData }[]): string {
+  private renderMainCostChart(sortedData: { date: string; data: UsageData }[], monthly = false): string {
     if (sortedData.length === 0) {
       return '<div class="no-chart-data">No data available</div>';
     }
@@ -3293,7 +3293,7 @@ export class UsageWebviewProvider {
           'data-cost-output="' + cb.output + '" ' +
           'data-cost-cachewrite="' + cb.cacheWrite + '" ' +
           'data-cost-cacheread="' + cb.cacheRead + '" ' +
-          'title="' + this.escapeHtml(this.formatDate(date)) + ': ' + I18n.formatCurrency(data.totalCost) + '">' +
+          'title="' + this.escapeHtml(this.formatDate(date, monthly)) + ': ' + I18n.formatCurrency(data.totalCost) + '">' +
           costStack(data, barHeight) +
           '</div>' +
           '</div>'
@@ -3302,7 +3302,7 @@ export class UsageWebviewProvider {
       .join('');
 
     const xlabels = sortedData
-      .map(({ date }) => '<div class="hc-xlabel">' + this.getShortDate(date) + '</div>')
+      .map(({ date }) => '<div class="hc-xlabel">' + this.getShortDate(date, monthly) + '</div>')
       .join('');
 
     return (
@@ -3387,21 +3387,21 @@ export class UsageWebviewProvider {
     );
   }
 
-  private getShortDate(dateString: string): string {
+  private getShortDate(dateString: string, monthly = false): string {
     // Parse 'YYYY-MM-DD' textually — new Date('YYYY-MM-DD') is UTC midnight,
     // which shifts the displayed day back by one in negative-UTC timezones.
     const [y, m, d] = dateString.split('-').map(Number);
-    // Month-only dates (first of month) label as YYYY/MM for monthly charts.
-    if (dateString.endsWith('-01')) {
+    // Month-only dates label as YYYY/MM for monthly charts.
+    if (monthly) {
       return `${y}/${String(m).padStart(2, '0')}`;
     }
     return `${m}/${d}`;
   }
 
-  private formatDate(dateString: string): string {
+  private formatDate(dateString: string, monthly = false): string {
     const date = new Date(dateString);
-    // Check if this is a month-only date (ends with -01)
-    if (dateString.endsWith('-01')) {
+    // Month-only dates: show month/year for monthly aggregate data.
+    if (monthly) {
       return date.toLocaleDateString(I18n.getLocale(), I18n.dateFormatOptions({ year: 'numeric', month: 'long' }));
     }
     // Standard date formatting for daily data, locale + timezone aware.

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -3399,13 +3399,15 @@ export class UsageWebviewProvider {
   }
 
   private formatDate(dateString: string, monthly = false): string {
-    const date = new Date(dateString);
-    // Month-only dates: show month/year for monthly aggregate data.
+    // Parse textually to avoid UTC-midnight timezone shift (new Date('YYYY-MM-DD')
+    // is UTC midnight, which rolls back a day in negative-UTC timezones). The
+    // date keys are already timezone-correct from dayKeyInZone / monthKeyInZone.
+    const [y, m, d] = dateString.split('-').map(Number);
+    const date = new Date(Date.UTC(y, m - 1, d));
     if (monthly) {
-      return date.toLocaleDateString(I18n.getLocale(), I18n.dateFormatOptions({ year: 'numeric', month: 'long' }));
+      return date.toLocaleDateString(I18n.getLocale(), { year: 'numeric', month: 'long', timeZone: 'UTC' });
     }
-    // Standard date formatting for daily data, locale + timezone aware.
-    return date.toLocaleDateString(I18n.getLocale(), I18n.dateFormatOptions());
+    return date.toLocaleDateString(I18n.getLocale(), { ...I18n.dateFormatOptions(), timeZone: 'UTC' });
   }
 
   private getStyles(): string {


### PR DESCRIPTION
## Summary

Fixes a date formatting bug in the **This Month** tab's daily breakdown table: days that fall on the 1st of the month (e.g. `2026-07-01`) were displayed as month names ("July 2026") instead of specific dates ("2026/7/1"). Both `formatDate` and `getShortDate` used `dateString.endsWith('-01')` as a heuristic to distinguish monthly aggregate labels from daily dates, which breaks for any daily data point on the 1st. The fix replaces the heuristic with an explicit `monthly` parameter so the caller indicates the intended context.

## Linked issues

None

## Type of change

- [x] Bug fix (non-breaking) → `fix` (patch)
- [ ] New feature (non-breaking) → `feature` (minor)
- [ ] Breaking change (existing behaviour differs afterwards) → `breaking` (major)
- [ ] Documentation / CI / chore → `docs` / `ci` / `chore` (patch)

## How was this tested?

1. Built a `.vsix` (`npx @vscode/vsce package`) and installed it in VS Code
2. Verified that dates on the 1st of the month in the **This Month** tab now show as specific dates (e.g. `2026/7/1`)
3. Confirmed the **All Time** tab's monthly aggregates still display month names (e.g. "July 2026") — no regression
4. `npm run compile` is clean

## Checklist

- [x] `npm run compile` is clean
- [ ] User-facing strings go through `I18n` with **all six languages** filled — *N/A, only date formatting logic changed*
- [ ] `CHANGELOG.md` updated (user-visible changes)
- [ ] `README.md` updated if behaviour/settings changed — *N/A*
- [ ] New settings default to existing behaviour (opt-in) — *N/A*
- [x] No new runtime dependencies
