### PR TITLE
fix: one unprobeable .jsonl no longer blanks the whole usage dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
   are credited as development tools, separately from human contributors.
 
 ### Fixed
+- **Usage dashboard no longer blanks on one oversized non-transcript file** — a
+  single `.jsonl` with more than 1 MiB of leading lines that carry no
+  `timestamp` (such as a large workflow `journal.jsonl`, whose records hold
+  `type`/`key`/`result`/`agentId` and never a timestamp) made the
+  earliest-timestamp probe throw `TimestampProbeLimitError`. That rejection was
+  unhandled, so it aborted the whole load and left the dashboard empty on every
+  refresh (`failed=1`, `bytes=0` in diagnostics). The probe now fails soft for
+  that one file and the rest load normally.
 - **High-CPU refresh mitigation (#70)** — polling now always honors the
   configured 30–3600 second `refreshInterval`; file watching is quiet-debounce
   only and adds 60/120/300-second choices. First-timestamp reads stop after the

--- a/src/claudeUsageFiles.ts
+++ b/src/claudeUsageFiles.ts
@@ -204,11 +204,29 @@ export async function readEarliestTimestamp(
 export async function sortUsageFilesByEarliestTimestamp(
   entries: readonly UsageFileFingerprint[],
 ): Promise<{ files: string[]; bytesRead: number }> {
-  const stamped = await mapWithConcurrency(entries, 8, async (entry) => ({
-    file: entry.path,
-    discoveryIndex: entry.discoveryIndex,
-    ...(await readEarliestTimestamp(entry.path)),
-  }));
+  const stamped = await mapWithConcurrency(entries, 8, async (entry) => {
+    try {
+      return {
+        file: entry.path,
+        discoveryIndex: entry.discoveryIndex,
+        ...(await readEarliestTimestamp(entry.path)),
+      };
+    } catch {
+      // A single file we cannot probe must not abort the whole load. This
+      // happens when a .jsonl has more than 1 MiB of leading lines with no
+      // `timestamp` (readEarliestTimestamp throws TimestampProbeLimitError) —
+      // e.g. a large workflow `journal.jsonl`, whose records carry no
+      // timestamp — or on a transient read error. Fall back to a neutral stamp
+      // so the file sorts by discovery order, exactly as a small no-timestamp
+      // file already does, and the main reader still processes it.
+      return {
+        file: entry.path,
+        discoveryIndex: entry.discoveryIndex,
+        timestampMs: 0,
+        bytesRead: 0,
+      };
+    }
+  });
   stamped.sort((a, b) =>
     a.timestampMs - b.timestampMs || a.discoveryIndex - b.discoveryIndex,
   );

--- a/src/test/claudeUsageFiles.test.ts
+++ b/src/test/claudeUsageFiles.test.ts
@@ -191,3 +191,39 @@ test('equal or invalid timestamps preserve v2.2.0 discovery order', async () => 
   ]);
   assert.deepEqual(invalidPair.files, [invalid, invalid2]);
 });
+
+test('a single unprobeable file does not abort ordering the rest', async () => {
+  const { root } = await fixture();
+  const project = path.join(root, 'projects', '-tmp-demo');
+  const good = path.join(project, 'good.jsonl');
+  const journal = path.join(project, 'journal.jsonl');
+  await writeFile(good, '{"timestamp":"2026-01-01T00:00:00.000Z"}\n');
+  // A large workflow journal.jsonl: >1 MiB of records that never carry a
+  // `timestamp`, which makes readEarliestTimestamp throw TimestampProbeLimitError.
+  await writeFile(journal, '{"type":"result","key":"k","agentId":"a"}\n'.repeat(40_000));
+  await assert.rejects(
+    () => readEarliestTimestamp(journal),
+    { name: 'TimestampProbeLimitError' },
+  );
+
+  const make = async (file: string, discoveryIndex: number) => {
+    const fileStat = await stat(file);
+    return {
+      path: file,
+      size: fileStat.size,
+      mtimeMs: fileStat.mtimeMs,
+      discoveryIndex,
+      dev: fileStat.dev > 0 && fileStat.ino > 0 ? fileStat.dev : undefined,
+      ino: fileStat.dev > 0 && fileStat.ino > 0 ? fileStat.ino : undefined,
+    };
+  };
+
+  // Before the fix this rejected — one unprobeable file zeroed the whole load.
+  // Now it resolves and keeps every file, the unprobeable one stamped 0 so it
+  // sorts ahead of the real timestamp by discovery order.
+  const sorted = await sortUsageFilesByEarliestTimestamp([
+    await make(journal, 0),
+    await make(good, 1),
+  ]);
+  assert.deepEqual(sorted.files, [journal, good]);
+});


### PR DESCRIPTION
大家好

## Problem

`sortUsageFilesByEarliestTimestamp` maps `readEarliestTimestamp` over every
discovered `.jsonl` via `mapWithConcurrency`, with no per-file error handling.
`readEarliestTimestamp` throws `TimestampProbeLimitError` when a file has more
than 1 MiB of leading lines that carry no `timestamp` field (covered by the
existing "timestamp probing is bounded when no valid timestamp exists" test).

That rejection is unhandled, so `Promise.all` rejects, the error unwinds out of
`loadUsageRecords`, and the outer catch returns `{ records: [] }` with
`filesFailed = Math.max(filesFailed, 1)`. A single such file empties the entire
file-based dashboard on every refresh. Diagnostics report `failed=1` with
`bytes=0`. The API quota path is separate and keeps working, so only the
usage/history panel goes blank.

The file type that triggers this in normal use is a workflow `journal.jsonl`:
its records contain `type`, `key`, `result`, and `agentId`, never a
`timestamp`, and a workflow run with a few hundred sub-agents produces a
`journal.jsonl` over 1 MiB.

## Origin

This surfaced from Claude Code's Workflow feature (multi-agent orchestration).
Each run writes a journal at
`~/.claude/projects/<project>/<session>/subagents/workflows/<workflow-id>/journal.jsonl`,
one line per sub-agent lifecycle event: a `started` line and a `result` line
per agent, each holding `type`, `key`, `result`, and `agentId` and no
`timestamp`. The `result` values make some lines large. A single run that
fanned out to roughly two hundred sub-agents produced a 1.32 MB, 402-line
journal, over the 1 MiB probe limit. From then on every refresh returned empty
records (`failed=1`, `bytes=0`) and the dashboard stayed blank while the
status-bar quota kept updating, which presented as a rendering fault rather
than a load abort.

## Reproduction

1. Create a `.jsonl` under `~/.claude/projects/<project>/` whose first 1 MiB
   contains no line with a `timestamp` field:

   ```
   node -e 'const fs=require("fs"),os=require("os"),p=require("path");const d=p.join(os.homedir(),".claude","projects","repro");fs.mkdirSync(d,{recursive:true});fs.writeFileSync(p.join(d,"journal.jsonl"),`{"type":"result","key":"k","agentId":"a"}\n`.repeat(40000))'
   ```

   Equivalently, run any workflow whose
   `subagents/workflows/<id>/journal.jsonl` grows past 1 MiB.
2. Open the extension or trigger a refresh.
3. The dashboard is empty. Show Diagnostic Logs reports `failed=1` and `bytes=0`
   on every refresh, while the status-bar quota continues to update.

With the fix, the same setup loads the remaining files normally and the
dashboard populates; the oversized file is skipped for ordering.

## Fix

Catch the per-file probe failure in `sortUsageFilesByEarliestTimestamp` and fall
back to `timestampMs: 0`, so the file sorts by discovery order — the same value
`readEarliestTimestamp` already returns for a small file that has no timestamp.
One unprobeable or transiently unreadable file no longer aborts the batch, and
the file is still passed to the main reader.

`readEarliestTimestamp` and its guard test are unchanged.

## Test

Adds "a single unprobeable file does not abort ordering the rest" to
`src/test/claudeUsageFiles.test.ts`: a >1 MiB no-`timestamp` `journal.jsonl`
beside a normal file. It asserts `readEarliestTimestamp` still rejects on the
journal, and that `sortUsageFilesByEarliestTimestamp` resolves and returns both
files.

`CHANGELOG.md` is updated. `package.json` version is left unchanged per
CONTRIBUTING.

谢谢