### PR TITLE
fix: track Claude Opus 5 as a 1M-context model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
   are credited as development tools, separately from human contributors.
 
 ### Fixed
+- **Opus 5 context window** — `claude-opus-5` reported a 200 000-token window
+  as if it were exact, so the status bar and dashboard showed a context
+  percentage five times too high. Claude Code writes the plain `claude-opus-5`
+  id to its JSONL even for the 1M-context variant, so the existing `[1m]`
+  marker never covered it. The major-version check now recognises Opus 5+
+  alongside Sonnet 5+, and `claude-opus-5` is an explicit entry in the pricing
+  table (same $5 / $25 current-Opus tier the family fallback already resolved,
+  minus the spurious `Unknown model` diagnostic).
+
 - **High-CPU refresh mitigation (#70)** — polling now always honors the
   configured 30–3600 second `refreshInterval`; file watching is quiet-debounce
   only and adds 60/120/300-second choices. First-timestamp reads stop after the

--- a/src/dataLoader.ts
+++ b/src/dataLoader.ts
@@ -1194,15 +1194,16 @@ export class ClaudeDataLoader {
   }
 
   /** Model context-window size in tokens, plus whether it's a guess. Current
-   * Claude (Opus 4.6+, Sonnet 4.6+, Sonnet 5+, Fable/Mythos 5) is 1M; Haiku
-   * and older Claude are 200K; a "[1m]" suffix forces 1M (the marker
+   * Claude (Opus 4.6+, Opus 5+, Sonnet 4.6+, Sonnet 5+, Fable/Mythos 5) is 1M;
+   * Haiku and older Claude are 200K; a "[1m]" suffix forces 1M (the marker
    * pricing.ts strips). A user override (>0) wins outright and is treated as
    * exact. Unrecognised / proxied models fall back to 200K and are flagged
    * `estimated` so the UI can mark the percentage as approximate.
    * Sonnet 5 (`claude-sonnet-5`) verified 2026-07-01 —
    * https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5
    * ("1M tokens is both the default and the maximum; there is no smaller
-   * context variant"). */
+   * context variant"). Opus 5 (`claude-opus-5`) verified 2026-07-28 —
+   * https://platform.claude.com/docs/en/about-claude/models/overview */
   private static contextWindowFor(
     model: string,
     override: number = 0
@@ -1221,10 +1222,9 @@ export class ClaudeDataLoader {
     if (/opus-4-(?:[6-9]|\d\d)\b/.test(m) || /sonnet-4-(?:[6-9]|\d\d)\b/.test(m)) {
       return { tokens: 1_000_000, estimated: false };
     }
-    // Sonnet 5.x+ (e.g. "claude-sonnet-5") has no "-4-" segment to match
-    // above, so check the major version directly. (Opus 5 doesn't exist yet —
-    // don't guess its window size here.)
-    if (/sonnet-(?:[5-9]|\d\d)(?:-|\b)/.test(m)) {
+    // Opus 5.x+ / Sonnet 5.x+ (e.g. "claude-opus-5") have no "-4-" segment to
+    // match above, so check the major version directly.
+    if (/(?:opus|sonnet)-(?:[5-9]|\d\d)(?:-|\b)/.test(m)) {
       return { tokens: 1_000_000, estimated: false };
     }
     if (/haiku/.test(m) || /opus|sonnet/.test(m)) {

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -231,6 +231,9 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   'claude-fable-5': FABLE_5,
   'claude-mythos-5': FABLE_5,
 
+  // Claude Opus 5 — same current-Opus tier rate, verified 2026-07-28.
+  'claude-opus-5': OPUS_CURRENT,
+
   // Claude Opus 4.8 / 4.7 / 4.6 — current Opus tier rate, verified 2026-06-09
   // against the official pricing page ($5 / $25 / $6.25 / $0.5 per MTok).
   'claude-opus-4-8': OPUS_CURRENT,

--- a/src/test/dataLoader.test.ts
+++ b/src/test/dataLoader.test.ts
@@ -31,6 +31,23 @@ test('getCurrentContextInfo reports a 1M window for Sonnet 5', () => {
   assert.equal(info!.estimated, false);
 });
 
+test('getCurrentContextInfo reports a 1M window for Opus 5, with or without the [1m] marker', () => {
+  for (const model of ['claude-opus-5', 'claude-opus-5[1m]']) {
+    const info = ClaudeDataLoader.getCurrentContextInfo([record(model)]);
+    assert.ok(info, `expected context info for ${model}, got null`);
+    assert.equal(info!.windowTokens, 1_000_000, model);
+    assert.equal(info!.estimated, false, model);
+  }
+});
+
+test('getCurrentContextInfo keeps the 200K window for pre-4.6 Opus and Sonnet', () => {
+  for (const model of ['claude-opus-4-20250514', 'claude-sonnet-4-5-20250929', 'claude-3-5-sonnet-20241022']) {
+    const info = ClaudeDataLoader.getCurrentContextInfo([record(model)]);
+    assert.ok(info, `expected context info for ${model}, got null`);
+    assert.equal(info!.windowTokens, 200_000, model);
+  }
+});
+
 test('an injected manifest is authoritative and returns anonymous load counters', async () => {
   const manifestRoot = await mkdtemp(path.join(os.tmpdir(), 'ccu-loader-manifest-'));
   const emptyArgumentRoot = await mkdtemp(path.join(os.tmpdir(), 'ccu-loader-empty-'));

--- a/src/test/pricing.test.ts
+++ b/src/test/pricing.test.ts
@@ -67,6 +67,15 @@ test('cache-write pricing falls back to the 5-minute rate when no TTL split is p
   assert.ok(Math.abs(breakdown.cacheWrite - 6.25) < 1e-9, `expected ~6.25, got ${breakdown.cacheWrite}`);
 });
 
+test('getModelPricing resolves Opus 5 from the exact table, long-context variant included', () => {
+  for (const model of ['claude-opus-5', 'claude-opus-5[1m]']) {
+    const pricing = getModelPricing(model);
+    assert.ok(pricing, `expected pricing for ${model}, got null`);
+    assert.equal(pricing!.input_cost_per_token, 5 / 1_000_000, model);
+    assert.equal(pricing!.output_cost_per_token, 25 / 1_000_000, model);
+  }
+});
+
 test('getModelPricing falls back to the right family for an unknown snapshot', () => {
   // An unreleased Opus snapshot isn't in the exact table; it should still
   // resolve to the current Opus tier ($5/MTok input) rather than a wrong rate.


### PR DESCRIPTION
## Problem

`claude-opus-5` is reported with a 200 000-token context window, flagged as **exact**. Because a real Opus 5 session routinely exceeds that, the context indicator doesn't just read high — it reads *over 100%*, and `estimated: false` means the UI has no reason to soften it.

Measured on my own logs (31 060 records, via `getCurrentContextInfo`):

| build | window | context tokens | reported |
|---|---|---|---|
| `main` | 200 000 | 361 850 | **180.9%** |
| this branch | 1 000 000 | 362 493 | **36.2%** |

## Root cause

`contextWindowFor` has a `[1m]`-suffix escape hatch and a major-version check, but the latter only matched `sonnet-`:

```ts
// Sonnet 5.x+ (e.g. "claude-sonnet-5") has no "-4-" segment to match
// above, so check the major version directly. (Opus 5 doesn't exist yet —
// don't guess its window size here.)
if (/sonnet-(?:[5-9]|\d\d)(?:-|\b)/.test(m)) {
```

That comment is now out of date, and the `[1m]` hatch doesn't cover the gap: **Claude Code writes the bare `claude-opus-5` id to its JSONL even when the session is running the 1M-context variant.** Across three days of my logs:

```
7750 "model":"claude-opus-5"      ← no [1m] marker, ever
 723 "model":"claude-opus-4-7"
 672 "model":"claude-sonnet-5"
 637 "model":"claude-opus-4-8"
```

So `claude-opus-5` falls through to the generic `/haiku|opus|sonnet/` branch and gets 200K.

## Fix

One alternation, covering Opus 5+ alongside Sonnet 5+:

```ts
if (/(?:opus|sonnet)-(?:[5-9]|\d\d)(?:-|\b)/.test(m)) {
```

Older models are unaffected — the `(?:-|\b)` anchor still prevents a date suffix from matching, so `claude-3-5-sonnet-20241022`, `claude-sonnet-4-5-20250929` and `claude-opus-4-20250514` keep their 200K window. There's a regression test pinning that.

`claude-opus-5` also gets an explicit `MODEL_PRICING` entry. **No cost figure changes** — `inferPricingByFamily` already resolved it to the correct current-Opus tier. The entry mirrors the existing `claude-sonnet-5` anchor and removes a spurious `Unknown model: claude-opus-5` line from the diagnostic output, which seemed worth avoiding in an extension whose diagnostics users are asked to attach to bug reports.

Opus 5 pricing ($5 / $25 per MTok) and context window verified 2026-07-28 against <https://platform.claude.com/docs/en/about-claude/models/overview> — for Opus 5, as for Sonnet 5, 1M is both the default and the maximum, with no smaller context variant.

## Tests

Red first, then green. The failing run was `actual: 200000, expected: 1000000`.

- `getCurrentContextInfo reports a 1M window for Opus 5, with or without the [1m] marker`
- `getCurrentContextInfo keeps the 200K window for pre-4.6 Opus and Sonnet` (regression guard)
- `getModelPricing resolves Opus 5 from the exact table, long-context variant included`

`npm test` → **172 tests, 171 pass, 0 fail, 1 skipped** (the skip is pre-existing).

Also smoke-tested as an installed VSIX in VS Code 1.129.1 on Linux.

## Notes for review

- `CHANGELOG.md` has an entry under 2.2.1 → Fixed. I didn't touch the READMEs: 2.2.1 has no "what's new" section in any of the seven yet, so there was nowhere consistent to put it. Happy to add one if you'd rather it landed there too.
- Not addressed here, but possibly worth its own issue: **Opus 5 fast mode bills at $10 / $50 per MTok, not $5 / $25.** On Opus 5 that's a `speed: "fast"` request parameter rather than a distinct model id, so I couldn't tell from my logs whether it's distinguishable in the JSONL at all. If it is, current pricing under-counts those turns.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
