### PR TITLE
feat: official quota thresholds and a tidier usage credits tooltip row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
 - **Reset times read to the minute** — they were shown truncated to the second,
   so a cap resetting at 16:59:59 displayed as "16:59" while the cap it resets
   alongside displayed "17:00".
+- **Quota warns at the same points as the official Claude app.**
+  The quota indicator and every bar in its tooltip now turn amber at 75% and red at 90%, instead of 80% and 95%.
+  The context-window indicator keeps the earlier 80% and 95% steps.
 
 ## [2.2.2] — Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,8 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
   Indonesian entry showed English text in the settings panel.
 
 ### Added
-- **Usage credits in the quota tooltip** — the amount spent this month against
-  your cap, and the date it resets, once you have actually spent some. The figure
-  stays visible after you switch credits off, since the spend already happened,
-  and it copes with a cap you have raised, lowered, or removed entirely.
+- **Usage credits in the quota tooltip** — the amount spent this month and the date it resets, once you have actually spent some.
+  The figure stays visible after you switch credits off, since the spend already happened.
 
 ### Changed
 - **`showOpusWeekly` is now `showScopedWeekly`** — the setting no longer names a

--- a/src/quotaFormat.ts
+++ b/src/quotaFormat.ts
@@ -1,7 +1,8 @@
-// Pure helpers for the quota STATUS-BAR text (not the tooltip). Dependency-free
-// and unit-tested. Product requirement: the status bar must stay clean — no
-// dense colon-heavy output like "5h:6%:4.8h | wk:1%:1.6d". Reset countdowns are
-// opt-in (showResetInStatusBar); the full reset detail lives in the tooltip.
+// Pure helpers for quota presentation: the status-bar text, the tooltip's own
+// cells, and the fill thresholds both share. Dependency-free and unit-tested.
+// Product requirement: the status bar must stay clean — no dense colon-heavy
+// output like "5h:6%:4.8h | wk:1%:1.6d". Reset countdowns are opt-in
+// (showResetInStatusBar); the full reset detail lives in the tooltip.
 
 import { QuotaWindow, groupQuotaRows } from './quotaWindows';
 
@@ -250,4 +251,38 @@ export function formatQuotaStatusText(windows: QuotaWindow[] | null, opts: Quota
  * tooltip lists every window unconditionally, so the figure stays reachable. */
 export function worstShownUtilisation(windows: QuotaWindow[] | null, opts: QuotaStatusOptions): number {
   return shownWindows(windows, opts).reduce((worst, w) => Math.max(worst, w.utilization), 0);
+}
+
+/** How full a bar is, in the three steps the UI paints. */
+export type FillLevel = 'normal' | 'warning' | 'error';
+
+/** The percentages at which a fill turns amber and then red. Both are inclusive
+ * lower bounds. */
+export interface FillThresholds {
+  warnAt: number;
+  errorAt: number;
+}
+
+/** Quota bars and the quota status-bar background. These follow the official
+ * Claude app rather than being chosen here, so a user reading both sees the same
+ * window called amber or red in each. */
+export const QUOTA_FILL_THRESHOLDS: FillThresholds = { warnAt: 75, errorAt: 90 };
+
+/** The context-window indicator, which deliberately keeps the later pair the
+ * quota bars used to share. A nearly-full context is recoverable — compact or
+ * start a fresh session — so warning at 75% would cry wolf on a normal long
+ * session, whereas a spent quota genuinely blocks work until it resets. */
+export const CONTEXT_FILL_THRESHOLDS: FillThresholds = { warnAt: 80, errorAt: 95 };
+
+/** Which step a fill percentage lands on. Unclamped input is fine: anything at
+ * or above `errorAt` is an error and anything below `warnAt`, negative included,
+ * is normal. */
+export function fillLevel(pct: number, thresholds: FillThresholds): FillLevel {
+  if (pct >= thresholds.errorAt) {
+    return 'error';
+  }
+  if (pct >= thresholds.warnAt) {
+    return 'warning';
+  }
+  return 'normal';
 }

--- a/src/quotaWindows.ts
+++ b/src/quotaWindows.ts
@@ -53,8 +53,8 @@ export interface QuotaCredits {
   limit: number | null;
   currency: string;
   /** used/limit as 0-100, or null when there is no finite cap to measure
-   *  against. Drives the progress bar only: the row shows the amount, since a
-   *  percentage of a cap the user can change at will says little. */
+   *  against. Not currently displayed: the credits row shows the amount and no
+   *  bar, since a percentage of a cap the user can change at will says little. */
   percent: number | null;
   /** Local midnight on the 1st of next month, when the monthly cap rolls over.
    *  Derived, not reported: the payload carries no reset for credits, but the

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -2,11 +2,16 @@ import * as vscode from 'vscode';
 import { ClaudeApiUsageResponse, ContextWindowInfo, UsageData } from './types';
 import { I18n } from './i18n';
 import {
+  CONTEXT_FILL_THRESHOLDS,
+  QUOTA_FILL_THRESHOLDS,
+  fillLevel,
   formatMonthlyReset,
   formatQuotaStatusText,
   formatResetCell,
   formatSharePercent,
   worstShownUtilisation,
+  FillLevel,
+  FillThresholds,
   QuotaStatusOptions,
   ResetCountdownFormat
 } from './quotaFormat';
@@ -201,14 +206,9 @@ export class StatusBarManager {
     const approx = info.estimated ? '~' : '';
     this.contextItem.text = `$(layers) ${approx}${Math.round(pct)}%`;
 
-    // Same thresholds as the quota item: amber at 80%, red at 95%.
-    if (pct >= 95) {
-      this.contextItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
-    } else if (pct >= 80) {
-      this.contextItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
-    } else {
-      this.contextItem.backgroundColor = undefined;
-    }
+    // Amber at 80%, red at 95% — see CONTEXT_FILL_THRESHOLDS for why this no
+    // longer matches the quota item.
+    this.contextItem.backgroundColor = this.fillBackground(fillLevel(pct, CONTEXT_FILL_THRESHOLDS));
 
     const t = I18n.t.popup;
     const md = new vscode.MarkdownString();
@@ -222,7 +222,7 @@ export class StatusBarManager {
     const freeSpace = Math.max(0, info.windowTokens - info.contextTokens);
     const num = (n: number): string => I18n.formatNumber(n);
     let html = '<table>';
-    html += `<tr><td>${this.progressBarSvg(pct, 30)}</td><td align="right"><b>${pct.toFixed(1)}%</b></td></tr>`;
+    html += `<tr><td>${this.progressBarSvg(pct, 30, CONTEXT_FILL_THRESHOLDS)}</td><td align="right"><b>${pct.toFixed(1)}%</b></td></tr>`;
     html += `<tr><td>${t.inputTokens}</td><td align="right">${num(info.inputTokens)}</td></tr>`;
     html += `<tr><td>${t.cacheRead}</td><td align="right">${num(info.cacheReadTokens)}</td></tr>`;
     html += `<tr><td>${t.cacheCreation}</td><td align="right">${num(info.cacheCreationTokens)}</td></tr>`;
@@ -268,14 +268,9 @@ export class StatusBarManager {
 
     this.quotaItem.text = `$(dashboard) ${text}`;
 
-    // Stay quiet until usage actually gets high.
-    if (worstPct >= 95) {
-      this.quotaItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
-    } else if (worstPct >= 80) {
-      this.quotaItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
-    } else {
-      this.quotaItem.backgroundColor = undefined;
-    }
+    // Stay quiet until usage actually gets high (amber at 75%, red at 90%, as
+    // the official Claude app does — QUOTA_FILL_THRESHOLDS).
+    this.quotaItem.backgroundColor = this.fillBackground(fillLevel(worstPct, QUOTA_FILL_THRESHOLDS));
 
     this.quotaItem.tooltip = this.createQuotaTooltip(live, creditsFromUsage(usageLimits));
     this.quotaItem.show();
@@ -458,6 +453,18 @@ export class StatusBarManager {
     );
   }
 
+  /** Status-bar item background for a fill level. Kept beside the bar colours
+   * below so the two signals for one indicator can only be changed together. */
+  private fillBackground(level: FillLevel): vscode.ThemeColor | undefined {
+    if (level === 'error') {
+      return new vscode.ThemeColor('statusBarItem.errorBackground');
+    }
+    if (level === 'warning') {
+      return new vscode.ThemeColor('statusBarItem.warningBackground');
+    }
+    return undefined;
+  }
+
   /** Progress bar: nested <span>s with solid background colours so the
    * sanitiser keeps everything we need. The outer span paints the full
    * 100% track in solid medium gray (#bbb) — visible on both light and
@@ -465,15 +472,19 @@ export class StatusBarManager {
    * The inner span paints the filled portion in colour, sitting on top of
    * the gray track.
    *
-   * Bar colour mirrors the status-bar warning/error thresholds (amber at
-   * >=80%, red at >=95%) so the visual signal matches the indicator. */
-  private progressBarSvg(pct: number, total: number = 24): string {
+   * `thresholds` decides where amber and red begin, so a bar always agrees with
+   * the background of the item it belongs to. Quota and context deliberately
+   * pass different pairs — see QUOTA_FILL_THRESHOLDS. */
+  private progressBarSvg(pct: number, total: number = 24, thresholds: FillThresholds = QUOTA_FILL_THRESHOLDS): string {
     const TOTAL = total;
     const filled = Math.max(0, Math.min(TOTAL, Math.round((pct / 100) * TOTAL)));
     const empty = TOTAL - filled;
-    let color = '#4caf50';                    // green
-    if (pct >= 95) { color = '#f44336'; }     // red
-    else if (pct >= 80) { color = '#ff9800'; } // amber
+    const level = fillLevel(pct, thresholds);
+    const color = level === 'error'
+      ? '#f44336'                             // red
+      : level === 'warning'
+        ? '#ff9800'                           // amber
+        : '#4caf50';                          // green
     const nbsp = (n: number) => '&nbsp;'.repeat(n);
     return (
       `<span style="background-color:#bbbbbb;font-size:48%;border-radius:3px;">` +

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -394,19 +394,13 @@ export class StatusBarManager {
     }
     if (credits && credits.used > 0) {
       // The amount rather than a percentage: the cap is user-adjustable and may
-      // be unlimited, so a share of it says little. The bar still tracks the cap
-      // whenever there is a finite one.
+      // be unlimited, so a share of it says little.
       const spent = this.formatCreditAmount(credits.used, credits.currency);
       const amount = credits.limit === null
         ? spent
         : `${spent} / ${this.formatCreditAmount(credits.limit, credits.currency)}`;
       md.appendMarkdown(
-        this.quotaRowHtml(
-          t.quotaCredits,
-          amount,
-          credits.percent ?? 0,
-          formatMonthlyReset(credits.resetsAt)
-        )
+        this.creditsRowHtml(t.quotaCredits, amount, formatMonthlyReset(credits.resetsAt))
       );
     }
     md.appendMarkdown(`</table>\n\n*${t.quotaHint}*`);
@@ -448,6 +442,22 @@ export class StatusBarManager {
       `<td align="left"><b>${label}</b></td>` +
       `<td>${bar}</td>` +
       `<td align="right">${shares}</td>` +
+      `<td align="right">&nbsp;&nbsp;${resets}</td>` +
+      `</tr>\n`
+    );
+  }
+
+  /** The credits row carries no bar (the figure is an amount of money, not a
+   * share of a fixed cap), so its value spans the bar and share columns,
+   * left-aligned to start where the bars start. Parking the amount in the
+   * right-aligned share column instead stretched that column to the amount's
+   * width, pushing every percentage away from its bar the moment credits
+   * appeared. */
+  private creditsRowHtml(label: string, amount: string, resets: string): string {
+    return (
+      `<tr>` +
+      `<td align="left"><b>${label}</b></td>` +
+      `<td colspan="2" align="left">${amount}</td>` +
       `<td align="right">&nbsp;&nbsp;${resets}</td>` +
       `</tr>\n`
     );

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -393,12 +393,9 @@ export class StatusBarManager {
       );
     }
     if (credits && credits.used > 0) {
-      // The amount rather than a percentage: the cap is user-adjustable and may
-      // be unlimited, so a share of it says little.
-      const spent = this.formatCreditAmount(credits.used, credits.currency);
-      const amount = credits.limit === null
-        ? spent
-        : `${spent} / ${this.formatCreditAmount(credits.limit, credits.currency)}`;
+      // Only the spent amount: the cap is user-adjustable and may be unlimited,
+      // so neither a share of it nor the cap itself says much beside the spend.
+      const amount = this.formatCreditAmount(credits.used, credits.currency);
       md.appendMarkdown(
         this.creditsRowHtml(t.quotaCredits, amount, formatMonthlyReset(credits.resetsAt))
       );

--- a/src/test/quotaFormat.test.ts
+++ b/src/test/quotaFormat.test.ts
@@ -5,7 +5,10 @@ import { test } from 'node:test';
 import * as assert from 'node:assert/strict';
 
 import {
+  CONTEXT_FILL_THRESHOLDS,
+  QUOTA_FILL_THRESHOLDS,
   compactReset,
+  fillLevel,
   formatMonthlyReset,
   formatQuotaStatusText,
   formatResetCell,
@@ -295,4 +298,52 @@ test('a genuinely fractional share keeps a decimal whatever the field says', () 
   // Never round real precision away just because the field is nominally integral.
   assert.equal(formatSharePercent(8.42, 0), '8.4%');
   assert.equal(formatSharePercent(0.5, 0), '0.5%');
+});
+
+
+// Fill thresholds drive both the tooltip bar colour and the status-bar item
+// background, so they are pinned here rather than left as literals at each use.
+// Quota follows the official Claude app (75/90); the context window keeps the
+// later 80/95 pair, since a nearly-full context is recoverable by compacting
+// while a spent quota is not.
+
+test('quota thresholds match the official Claude app', () => {
+  assert.deepEqual(QUOTA_FILL_THRESHOLDS, { warnAt: 75, errorAt: 90 });
+});
+
+test('the context window keeps its own, later thresholds', () => {
+  assert.deepEqual(CONTEXT_FILL_THRESHOLDS, { warnAt: 80, errorAt: 95 });
+});
+
+test('quota fill level steps at 75 and 90 inclusive', () => {
+  const level = (pct: number) => fillLevel(pct, QUOTA_FILL_THRESHOLDS);
+  assert.equal(level(0), 'normal');
+  assert.equal(level(74.9), 'normal');
+  assert.equal(level(75), 'warning');
+  assert.equal(level(89.9), 'warning');
+  assert.equal(level(90), 'error');
+  assert.equal(level(100), 'error');
+});
+
+test('context fill level steps at 80 and 95 inclusive', () => {
+  const level = (pct: number) => fillLevel(pct, CONTEXT_FILL_THRESHOLDS);
+  assert.equal(level(79.9), 'normal');
+  assert.equal(level(80), 'warning');
+  assert.equal(level(94.9), 'warning');
+  assert.equal(level(95), 'error');
+});
+
+test('the two pairs disagree exactly in the 75-80 and 90-95 bands', () => {
+  // The band that motivated the split: quota warns where the context bar is
+  // still quiet, and reds out where it is merely amber.
+  assert.equal(fillLevel(77, QUOTA_FILL_THRESHOLDS), 'warning');
+  assert.equal(fillLevel(77, CONTEXT_FILL_THRESHOLDS), 'normal');
+  assert.equal(fillLevel(92, QUOTA_FILL_THRESHOLDS), 'error');
+  assert.equal(fillLevel(92, CONTEXT_FILL_THRESHOLDS), 'warning');
+});
+
+test('out-of-range fills clamp to the nearest level', () => {
+  // Callers clamp before drawing, but a level must never come back undefined.
+  assert.equal(fillLevel(-5, QUOTA_FILL_THRESHOLDS), 'normal');
+  assert.equal(fillLevel(140, QUOTA_FILL_THRESHOLDS), 'error');
 });

--- a/src/test/statusBarThresholds.test.ts
+++ b/src/test/statusBarThresholds.test.ts
@@ -1,0 +1,112 @@
+// Wiring test for the fill thresholds. quotaFormat.test.ts pins the pairs
+// themselves; this pins which indicator gets which, because the interesting
+// failure is a correct pair handed to the wrong bar. statusBar.ts imports
+// vscode, so the module is loaded against a stub (see extensionWindowActivity).
+
+import { test } from 'node:test';
+import * as assert from 'node:assert/strict';
+
+import { CONTEXT_FILL_THRESHOLDS, QUOTA_FILL_THRESHOLDS, fillLevel } from '../quotaFormat';
+
+const GREEN = '#4caf50';
+const AMBER = '#ff9800';
+const RED = '#f44336';
+
+type StatusBarModule = typeof import('../statusBar');
+
+/** Records the id it was constructed with, so a background assertion can name
+ * the theme colour rather than compare opaque stubs. */
+class RecordingThemeColor {
+  constructor(public readonly id: string) {}
+}
+
+function loadStatusBarModule(): StatusBarModule {
+  const moduleLoader = require('node:module') as {
+    _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+  };
+  const originalLoad = moduleLoader._load;
+  const vscodeStub: any = new Proxy(function () {}, {
+    get: (_target, property) => {
+      if (property === 'then') {
+        return undefined;
+      }
+      if (property === 'ThemeColor') {
+        return RecordingThemeColor;
+      }
+      return vscodeStub;
+    },
+    apply: () => vscodeStub,
+    construct: () => vscodeStub,
+  });
+  moduleLoader._load = function (request, parent, isMain): unknown {
+    if (request === 'vscode') {
+      return vscodeStub;
+    }
+    return Reflect.apply(originalLoad, this, [request, parent, isMain]);
+  };
+  try {
+    return require('../statusBar') as StatusBarModule;
+  } finally {
+    moduleLoader._load = originalLoad;
+  }
+}
+
+const { StatusBarManager } = loadStatusBarModule();
+
+/** The prototype alone — the real constructor builds live status-bar items. */
+function bareStatusBar(): any {
+  return Object.create(StatusBarManager.prototype) as any;
+}
+
+/** The fill colour the bar paints, read back off the rendered spans. The inner
+ * span carries the fill; the outer track is always #bbbbbb. */
+function barColor(pct: number, thresholds?: unknown): string {
+  const html: string =
+    thresholds === undefined
+      ? bareStatusBar().progressBarSvg(pct)
+      : bareStatusBar().progressBarSvg(pct, 24, thresholds);
+  const fills = [GREEN, AMBER, RED].filter((c) => html.includes(c));
+  assert.equal(fills.length, 1, `expected exactly one fill colour in ${html}`);
+  return fills[0];
+}
+
+test('a quota bar defaults to the quota thresholds', () => {
+  // The default matters: every quota row and the credits row rely on it.
+  assert.equal(barColor(74), GREEN);
+  assert.equal(barColor(75), AMBER);
+  assert.equal(barColor(89), AMBER);
+  assert.equal(barColor(90), RED);
+});
+
+test('the context bar is explicitly given the later thresholds', () => {
+  assert.equal(barColor(79, CONTEXT_FILL_THRESHOLDS), GREEN);
+  assert.equal(barColor(80, CONTEXT_FILL_THRESHOLDS), AMBER);
+  assert.equal(barColor(94, CONTEXT_FILL_THRESHOLDS), AMBER);
+  assert.equal(barColor(95, CONTEXT_FILL_THRESHOLDS), RED);
+});
+
+test('the two bars disagree in the bands the split created', () => {
+  // 77% is the whole point of the change: quota warns, context stays quiet.
+  assert.equal(barColor(77, QUOTA_FILL_THRESHOLDS), AMBER);
+  assert.equal(barColor(77, CONTEXT_FILL_THRESHOLDS), GREEN);
+  assert.equal(barColor(92, QUOTA_FILL_THRESHOLDS), RED);
+  assert.equal(barColor(92, CONTEXT_FILL_THRESHOLDS), AMBER);
+});
+
+test('the track is drawn even when the fill is empty', () => {
+  const html: string = bareStatusBar().progressBarSvg(0);
+  assert.ok(html.includes('#bbbbbb'), 'the gray track must survive a 0% fill');
+});
+
+test('item background follows the same level as the bar', () => {
+  const bg = (pct: number, thresholds: unknown): string | undefined =>
+    bareStatusBar().fillBackground(fillLevel(pct, thresholds as any))?.id;
+
+  assert.equal(bg(74, QUOTA_FILL_THRESHOLDS), undefined);
+  assert.equal(bg(75, QUOTA_FILL_THRESHOLDS), 'statusBarItem.warningBackground');
+  assert.equal(bg(90, QUOTA_FILL_THRESHOLDS), 'statusBarItem.errorBackground');
+  // Context keeps 80 / 95, so at 77 the item stays uncoloured.
+  assert.equal(bg(77, CONTEXT_FILL_THRESHOLDS), undefined);
+  assert.equal(bg(80, CONTEXT_FILL_THRESHOLDS), 'statusBarItem.warningBackground');
+  assert.equal(bg(95, CONTEXT_FILL_THRESHOLDS), 'statusBarItem.errorBackground');
+});


### PR DESCRIPTION
## Summary

Aligns the quota indicator's warning points with the official Claude app: bars and the status-bar background now turn amber at 75% and red at 90%, so both surfaces call the same window amber or red at the same moment (the context-window indicator deliberately keeps its 80/95 steps). Also tidies the usage-credits tooltip row introduced in #86: it shows only the spent amount, and the amount spans the bar and share columns so the percentage column no longer stretches away from the bars when the credits row appears.

## Linked issues

Relates to #86 (follow-up to the weekly quota windows and credits row added there).

## Type of change

- [x] New feature (non-breaking) → `feature` (minor)

## How was this tested?

- `npm test`: 262 tests, 261 pass, 1 pre-existing skip. New tests pin the quota/context threshold pairs and which indicator uses which (`statusBarThresholds.test.ts`, `quotaFormat.test.ts`).
- Extension Development Host (F5) against live Anthropic `/usage` data: with the credits row visible, the percentages stay snug against their bars and the amount starts at the bars' left edge.
- When Usage credits not enabled or not used, the "Usage credits" row will not occur. Example view below
<img width="392" height="249" alt="example" src="https://github.com/user-attachments/assets/9f0110a7-5168-4df4-a5b1-f46480983f5d" />

## Checklist

- [x] `npm run compile` is clean
- [x] User-facing strings go through `I18n` (no new strings; the row reuses `quotaCredits` from #86)
- [x] Behaviour/documentation changes update **all seven README editions** together (n/a: thresholds and tooltip layout are not documented in the READMEs)
- [x] `CHANGELOG.md` updated (user-visible changes)
- [x] `README.md` updated if behaviour/settings changed (n/a, see above)
- [x] New settings default to existing behaviour (n/a: no new settings)
- [x] No new runtime dependencies
