### PR TITLE
fix: make extension publishing resilient

### DIFF
--- a/.github/scripts/automationPolicy.test.mjs
+++ b/.github/scripts/automationPolicy.test.mjs
@@ -83,7 +83,30 @@ test('manual publish retries require a release tag and can target one registry',
   assert.match(workflow, /git rev-parse "refs\/tags\/\$RELEASE_TAG\^\{commit\}"/);
   assert.match(workflow, /if: github\.event_name == 'release' \|\| inputs\.publish_vscode/);
   assert.match(workflow, /if: github\.event_name == 'release' \|\| inputs\.publish_open_vsx/);
-  assert.doesNotMatch(workflow, /name: Set version from release tag\s*\n\s+if:/);
+  assert.match(workflow, /name: Verify release tag checkout[\s\S]*?Invalid release tag/);
+  assert.match(workflow, /verify-vsix\.mjs claude-code-usage\.vsix "\$\{RELEASE_TAG#v\}"/);
+});
+
+test('release delivery retries safely and does not let one registry block the other sinks', () => {
+  const workflow = read('.github/workflows/publish.yml');
+  const restoreAt = workflow.indexOf('name: Restore verified .vsix for a manual retry');
+  const verifyAt = workflow.indexOf('name: Verify .vsix');
+  const attachAt = workflow.indexOf('name: Attach .vsix to the GitHub Release');
+  const vscodeAt = workflow.indexOf('name: Publish to VS Code Marketplace');
+  const openVsxAt = workflow.indexOf('name: Publish to Open VSX Registry');
+  const resultAt = workflow.indexOf('name: Verify release delivery outcomes');
+
+  assert.ok(restoreAt >= 0 && verifyAt > restoreAt, 'manual retries must restore the canonical release asset first');
+  assert.ok(attachAt > verifyAt, 'verified VSIX must be attached');
+  assert.ok(vscodeAt > attachAt && openVsxAt > attachAt, 'release attachment must not depend on either registry');
+  assert.ok(resultAt > vscodeAt && resultAt > openVsxAt, 'registry failures must be reconciled after both attempts');
+  assert.match(workflow, /gh release download "\$RELEASE_TAG"[\s\S]*?claude-code-usage\.vsix/);
+  assert.equal((workflow.match(/steps\.restore_package\.outputs\.restored != 'true'/g) ?? []).length, 4);
+  assert.match(workflow, /tag_name: \$\{\{ env\.RELEASE_TAG \}\}/);
+  assert.match(workflow, /@vscode\/vsce@3\.9\.2 publish[\s\S]*?--skip-duplicate/);
+  assert.match(workflow, /ovsx@1\.1\.1 publish[\s\S]*?--skip-duplicate/);
+  assert.equal((workflow.match(/continue-on-error: true/g) ?? []).length, 3);
+  assert.equal((workflow.match(/for attempt in 1 2 3/g) ?? []).length, 2);
 });
 
 test('maintainer-only mention workflow retains its privileged Claude boundary', () => {

--- a/.github/scripts/automationPolicy.test.mjs
+++ b/.github/scripts/automationPolicy.test.mjs
@@ -84,12 +84,27 @@ test('manual publish retries require a release tag and can target one registry',
   assert.match(workflow, /if: github\.event_name == 'release' \|\| inputs\.publish_vscode/);
   assert.match(workflow, /if: github\.event_name == 'release' \|\| inputs\.publish_open_vsx/);
   assert.match(workflow, /name: Verify release tag checkout[\s\S]*?Invalid release tag/);
-  assert.match(workflow, /verify-vsix\.mjs claude-code-usage\.vsix "\$\{RELEASE_TAG#v\}"/);
+  assert.match(
+    workflow,
+    /name: Checkout current release verification policy[\s\S]*?ref: \$\{\{ github\.workflow_sha \}\}[\s\S]*?path: \.release-policy[\s\S]*?sparse-checkout: \.github\/scripts[\s\S]*?persist-credentials: false/,
+    'legacy release tags must use the current workflow verification policy',
+  );
+  assert.match(
+    workflow,
+    /node \.release-policy\/\.github\/scripts\/verify-vsix\.mjs claude-code-usage\.vsix "\$\{RELEASE_TAG#v\}"/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /run: node \.github\/scripts\/verify-vsix\.mjs claude-code-usage\.vsix/,
+    'manual retries cannot depend on a verifier present in the historical tag',
+  );
 });
 
 test('release delivery retries safely and does not let one registry block the other sinks', () => {
   const workflow = read('.github/workflows/publish.yml');
   const restoreAt = workflow.indexOf('name: Restore verified .vsix for a manual retry');
+  const packageAt = workflow.indexOf('name: Package .vsix');
+  const policyAt = workflow.indexOf('name: Checkout current release verification policy');
   const verifyAt = workflow.indexOf('name: Verify .vsix');
   const attachAt = workflow.indexOf('name: Attach .vsix to the GitHub Release');
   const vscodeAt = workflow.indexOf('name: Publish to VS Code Marketplace');
@@ -97,6 +112,10 @@ test('release delivery retries safely and does not let one registry block the ot
   const resultAt = workflow.indexOf('name: Verify release delivery outcomes');
 
   assert.ok(restoreAt >= 0 && verifyAt > restoreAt, 'manual retries must restore the canonical release asset first');
+  assert.ok(
+    packageAt >= 0 && policyAt > packageAt && verifyAt > policyAt,
+    'verification policy must be checked out only after packaging and before verification',
+  );
   assert.ok(attachAt > verifyAt, 'verified VSIX must be attached');
   assert.ok(vscodeAt > attachAt && openVsxAt > attachAt, 'release attachment must not depend on either registry');
   assert.ok(resultAt > vscodeAt && resultAt > openVsxAt, 'registry failures must be reconciled after both attempts');

--- a/.github/scripts/automationPolicy.test.mjs
+++ b/.github/scripts/automationPolicy.test.mjs
@@ -100,7 +100,10 @@ test('release delivery retries safely and does not let one registry block the ot
   assert.ok(attachAt > verifyAt, 'verified VSIX must be attached');
   assert.ok(vscodeAt > attachAt && openVsxAt > attachAt, 'release attachment must not depend on either registry');
   assert.ok(resultAt > vscodeAt && resultAt > openVsxAt, 'registry failures must be reconciled after both attempts');
+  assert.match(workflow, /ASSET_NAME="\$\(gh release view "\$RELEASE_TAG" --json assets --jq/);
+  assert.match(workflow, /if \[\[ "\$ASSET_NAME" == "claude-code-usage\.vsix" \]\]/);
   assert.match(workflow, /gh release download "\$RELEASE_TAG"[\s\S]*?claude-code-usage\.vsix/);
+  assert.doesNotMatch(workflow, /if gh release download/);
   assert.equal((workflow.match(/steps\.restore_package\.outputs\.restored != 'true'/g) ?? []).length, 4);
   assert.match(workflow, /tag_name: \$\{\{ env\.RELEASE_TAG \}\}/);
   assert.match(workflow, /@vscode\/vsce@3\.9\.2 publish[\s\S]*?--skip-duplicate/);

--- a/.github/scripts/automationPolicy.test.mjs
+++ b/.github/scripts/automationPolicy.test.mjs
@@ -110,6 +110,20 @@ test('release delivery retries safely and does not let one registry block the ot
   assert.equal((workflow.match(/timeout-minutes: 12/g) ?? []).length, 2);
 });
 
+test('release draft gets a post-merge reconciliation pass', () => {
+  const workflow = read('.github/workflows/release-drafter.yml');
+  assert.match(
+    workflow,
+    /pull_request_target:\s*\n\s+types: \[[^\]]*closed[^\]]*\]/,
+    'the merge-complete event must refresh the draft after the main push race',
+  );
+  assert.match(
+    workflow,
+    /if: >-\s*\n\s+github\.event_name != 'pull_request_target' \|\|\s*\n\s+github\.event\.action != 'closed' \|\|\s*\n\s+github\.event\.pull_request\.merged == true/,
+    'closing an unmerged PR must not rewrite the release draft',
+  );
+});
+
 test('maintainer-only mention workflow retains its privileged Claude boundary', () => {
   const privileged = read('.github/workflows/claude.yml');
   assert.match(privileged, /contents: write/);

--- a/.github/scripts/automationPolicy.test.mjs
+++ b/.github/scripts/automationPolicy.test.mjs
@@ -107,6 +107,7 @@ test('release delivery retries safely and does not let one registry block the ot
   assert.match(workflow, /ovsx@1\.1\.1 publish[\s\S]*?--skip-duplicate/);
   assert.equal((workflow.match(/continue-on-error: true/g) ?? []).length, 3);
   assert.equal((workflow.match(/for attempt in 1 2 3/g) ?? []).length, 2);
+  assert.equal((workflow.match(/timeout-minutes: 12/g) ?? []).length, 2);
 });
 
 test('maintainer-only mention workflow retains its privileged Claude boundary', () => {

--- a/.github/scripts/automationPolicy.test.mjs
+++ b/.github/scripts/automationPolicy.test.mjs
@@ -77,6 +77,8 @@ test('manual publish retries require a release tag and can target one registry',
   const workflow = read('.github/workflows/publish.yml');
   assert.match(workflow, /workflow_dispatch:\s*\n\s+inputs:\s*\n\s+tag:/);
   assert.match(workflow, /tag:\s*\n(?:\s+[^\n]+\n)*?\s+required: true/);
+  assert.match(workflow, /description: Existing release tag to retry; it must pass the current package policy/);
+  assert.doesNotMatch(workflow, /for example, v2\.2\.1/);
   assert.match(workflow, /RELEASE_TAG:.*github\.event\.release\.tag_name.*inputs\.tag/);
   assert.match(workflow, /uses: actions\/checkout@[a-f0-9]+[\s\S]*?ref: refs\/tags\/\$\{\{ env\.RELEASE_TAG \}\}/);
   assert.match(workflow, /git rev-parse HEAD/);

--- a/.github/scripts/automationPolicy.test.mjs
+++ b/.github/scripts/automationPolicy.test.mjs
@@ -128,7 +128,7 @@ test('release delivery retries safely and does not let one registry block the ot
   assert.equal((workflow.match(/steps\.restore_package\.outputs\.restored != 'true'/g) ?? []).length, 4);
   assert.match(workflow, /tag_name: \$\{\{ env\.RELEASE_TAG \}\}/);
   assert.match(workflow, /@vscode\/vsce@3\.9\.2 publish[\s\S]*?--skip-duplicate/);
-  assert.match(workflow, /ovsx@1\.1\.1 publish[\s\S]*?--skip-duplicate/);
+  assert.match(workflow, /ovsx@1\.2\.0 publish[\s\S]*?--skip-duplicate/);
   assert.equal((workflow.match(/continue-on-error: true/g) ?? []).length, 3);
   assert.equal((workflow.match(/for attempt in 1 2 3/g) ?? []).length, 2);
   assert.equal((workflow.match(/timeout-minutes: 12/g) ?? []).length, 2);

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,8 +113,20 @@ jobs:
         if: github.event_name == 'release' || steps.restore_package.outputs.restored != 'true'
         run: npx -y @vscode/vsce@3.9.2 package --out claude-code-usage.vsix
 
+      # Historical release tags predate the package verifier. Load the current
+      # workflow's verification policy only after packaging so policy files can
+      # neither be missing on an old tag nor leak into the VSIX being checked.
+      - name: Checkout current release verification policy
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-policy
+          sparse-checkout: .github/scripts
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Verify .vsix
-        run: node .github/scripts/verify-vsix.mjs claude-code-usage.vsix "${RELEASE_TAG#v}"
+        run: node .release-policy/.github/scripts/verify-vsix.mjs claude-code-usage.vsix "${RELEASE_TAG#v}"
 
       # Attach first so a transient registry outage cannot leave the GitHub
       # Release without its verified package. Manual retries overwrite the same

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,14 @@
 #        - stamps package.json's version from the release tag (so nobody
 #          hand-bumps it — the tag is the source of truth),
 #        - compiles + packages a .vsix,
-#        - publishes to the VS Code Marketplace (VSCE_PAT) and Open VSX (OVSX_PAT),
-#        - attaches the .vsix to the Release.
+#        - attaches the verified .vsix to the Release,
+#        - publishes independently to the VS Code Marketplace (VSCE_PAT) and
+#          Open VSX (OVSX_PAT), with bounded duplicate-safe retries.
 #
 # Trigger manually from Actions → Publish Extension → Run workflow to retry a
 # failed registry. Supply the existing release tag and select only the registry
-# that needs a retry; the workflow checks out and stamps that exact tag.
+# that needs a retry; the workflow reuses its attached VSIX or rebuilds the
+# missing asset from that exact tag.
 
 name: Publish Extension
 
@@ -56,6 +58,11 @@ jobs:
 
       - name: Verify release tag checkout
         run: |
+          TAG="$RELEASE_TAG"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: $TAG" >&2
+            exit 1
+          fi
           HEAD_COMMIT="$(git rev-parse HEAD)"
           TAG_COMMIT="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
           test "$HEAD_COMMIT" = "$TAG_COMMIT"
@@ -65,52 +72,117 @@ jobs:
         with:
           node-version: '20'
 
+      # A targeted manual retry should deliver the exact package that was
+      # already reviewed and attached. Build only when the release has no asset
+      # yet, which also repairs releases created by the former fail-fast flow.
+      - name: Restore verified .vsix for a manual retry
+        id: restore_package
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if gh release download "$RELEASE_TAG" --pattern claude-code-usage.vsix --clobber; then
+            echo "restored=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "restored=false" >> "$GITHUB_OUTPUT"
+            echo "No release asset found; rebuilding it from $RELEASE_TAG"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies
+        if: github.event_name == 'release' || steps.restore_package.outputs.restored != 'true'
         run: npm ci
 
       # The release tag is the single source of truth for the version. Stamp it
       # into package.json so vsce packages the right number — no human bump, no
       # tag-vs-package.json mismatch possible. Build-time only (not committed).
       - name: Set version from release tag
+        if: github.event_name == 'release' || steps.restore_package.outputs.restored != 'true'
         run: |
           TAG="$RELEASE_TAG"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Invalid release tag: $TAG" >&2
-            exit 1
-          fi
           VER="${TAG#v}"
           npm version "$VER" --no-git-tag-version --allow-same-version
           echo "package.json version set to $VER (from release $TAG)"
 
       - name: Compile
+        if: github.event_name == 'release' || steps.restore_package.outputs.restored != 'true'
         run: npm run compile
 
       - name: Package .vsix
-        run: npx -y @vscode/vsce@3.9.1 package --out claude-code-usage.vsix
+        if: github.event_name == 'release' || steps.restore_package.outputs.restored != 'true'
+        run: npx -y @vscode/vsce@3.9.2 package --out claude-code-usage.vsix
 
       - name: Verify .vsix
-        run: node .github/scripts/verify-vsix.mjs claude-code-usage.vsix
+        run: node .github/scripts/verify-vsix.mjs claude-code-usage.vsix "${RELEASE_TAG#v}"
+
+      # Attach first so a transient registry outage cannot leave the GitHub
+      # Release without its verified package. Manual retries overwrite the same
+      # deterministic asset instead of creating duplicates.
+      - name: Attach .vsix to the GitHub Release
+        id: attach_release
+        continue-on-error: true
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          files: claude-code-usage.vsix
+          tag_name: ${{ env.RELEASE_TAG }}
+          fail_on_unmatched_files: true
+          overwrite_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to VS Code Marketplace
+        id: publish_vscode
         if: github.event_name == 'release' || inputs.publish_vscode
-        run: npx -y @vscode/vsce@3.9.1 publish --packagePath claude-code-usage.vsix --pat "$VSCE_PAT"
+        continue-on-error: true
+        run: |
+          for attempt in 1 2 3; do
+            if npx -y @vscode/vsce@3.9.2 publish --packagePath claude-code-usage.vsix --skip-duplicate --pat "$VSCE_PAT"; then
+              exit 0
+            fi
+            if [[ "$attempt" == "3" ]]; then
+              exit 1
+            fi
+            sleep "$((attempt * 15))"
+          done
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Publish to Open VSX Registry
+        id: publish_open_vsx
         if: github.event_name == 'release' || inputs.publish_open_vsx
-        run: npx -y ovsx publish claude-code-usage.vsix --pat "$OVSX_PAT"
+        continue-on-error: true
+        run: |
+          for attempt in 1 2 3; do
+            if npx -y ovsx@1.1.1 publish claude-code-usage.vsix --skip-duplicate --pat "$OVSX_PAT"; then
+              exit 0
+            fi
+            if [[ "$attempt" == "3" ]]; then
+              exit 1
+            fi
+            sleep "$((attempt * 15))"
+          done
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
-      # The Release already exists (the maintainer just published it) and already
-      # has release-drafter's notes — so we only upload the asset, never
-      # regenerate the body.
-      - name: Attach .vsix to the GitHub Release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
-        with:
-          files: claude-code-usage.vsix
-          tag_name: ${{ github.event.release.tag_name }}
+      - name: Verify release delivery outcomes
+        if: always()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ATTACH_OUTCOME: ${{ steps.attach_release.outcome }}
+          PUBLISH_VSCODE: ${{ github.event_name == 'release' || inputs.publish_vscode }}
+          VSCODE_OUTCOME: ${{ steps.publish_vscode.outcome }}
+          PUBLISH_OPEN_VSX: ${{ github.event_name == 'release' || inputs.publish_open_vsx }}
+          OPEN_VSX_OUTCOME: ${{ steps.publish_open_vsx.outcome }}
+        run: |
+          failed=0
+          if [[ "$ATTACH_OUTCOME" != "success" ]]; then
+            echo "GitHub Release asset upload failed" >&2
+            failed=1
+          fi
+          if [[ "$PUBLISH_VSCODE" == "true" && "$VSCODE_OUTCOME" != "success" ]]; then
+            echo "VS Code Marketplace publish failed" >&2
+            failed=1
+          fi
+          if [[ "$PUBLISH_OPEN_VSX" == "true" && "$OPEN_VSX_OUTCOME" != "success" ]]; then
+            echo "Open VSX publish failed" >&2
+            failed=1
+          fi
+          exit "$failed"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          # ovsx 1.2.0 declares Node >=22. Keep the publishing runtime inside
+          # the supported engine contract instead of relying on accidental
+          # compatibility from a shorter-lived CLI code path.
+          node-version: '22'
 
       # A targeted manual retry should deliver the exact package that was
       # already reviewed and attached. Build only when the release has no asset

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,6 +133,7 @@ jobs:
         id: publish_vscode
         if: github.event_name == 'release' || inputs.publish_vscode
         continue-on-error: true
+        timeout-minutes: 12
         run: |
           for attempt in 1 2 3; do
             if npx -y @vscode/vsce@3.9.2 publish --packagePath claude-code-usage.vsix --skip-duplicate --pat "$VSCE_PAT"; then
@@ -150,6 +151,7 @@ jobs:
         id: publish_open_vsx
         if: github.event_name == 'release' || inputs.publish_open_vsx
         continue-on-error: true
+        timeout-minutes: 12
         run: |
           for attempt in 1 2 3; do
             if npx -y ovsx@1.1.1 publish claude-code-usage.vsix --skip-duplicate --pat "$OVSX_PAT"; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,8 @@
 # Trigger manually from Actions → Publish Extension → Run workflow to retry a
 # failed registry. Supply the existing release tag and select only the registry
 # that needs a retry; the workflow reuses its attached VSIX or rebuilds the
-# missing asset from that exact tag.
+# missing asset from that exact tag, then requires it to pass the current
+# package-safety policy before any delivery resumes.
 
 name: Publish Extension
 
@@ -27,7 +28,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing release tag to retry (for example, v2.2.1)
+        description: Existing release tag to retry; it must pass the current package policy
         required: true
         type: string
       publish_vscode:
@@ -113,9 +114,10 @@ jobs:
         if: github.event_name == 'release' || steps.restore_package.outputs.restored != 'true'
         run: npx -y @vscode/vsce@3.9.2 package --out claude-code-usage.vsix
 
-      # Historical release tags predate the package verifier. Load the current
-      # workflow's verification policy only after packaging so policy files can
-      # neither be missing on an old tag nor leak into the VSIX being checked.
+      # Some historical release tags predate the package verifier. Load the
+      # current workflow's policy only after packaging so policy files can
+      # neither be missing on the tag nor leak into the VSIX being checked.
+      # A package that no longer meets current safety policy fails closed.
       - name: Checkout current release verification policy
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,9 @@ jobs:
         id: restore_package
         if: github.event_name == 'workflow_dispatch'
         run: |
-          if gh release download "$RELEASE_TAG" --pattern claude-code-usage.vsix --clobber; then
+          ASSET_NAME="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[] | select(.name == "claude-code-usage.vsix") | .name')"
+          if [[ "$ASSET_NAME" == "claude-code-usage.vsix" ]]; then
+            gh release download "$RELEASE_TAG" --pattern claude-code-usage.vsix --clobber
             echo "restored=true" >> "$GITHUB_OUTPUT"
           else
             echo "restored=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,7 +170,7 @@ jobs:
         timeout-minutes: 12
         run: |
           for attempt in 1 2 3; do
-            if npx -y ovsx@1.1.1 publish claude-code-usage.vsix --skip-duplicate --pat "$OVSX_PAT"; then
+            if npx -y ovsx@1.2.0 publish claude-code-usage.vsix --skip-duplicate --pat "$OVSX_PAT"; then
               exit 0
             fi
             if [[ "$attempt" == "3" ]]; then

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,9 @@
 #
 # On every push to main, release-drafter (re)builds a single DRAFT Release with
 # categorised notes and the next semver version inferred from the merged PRs'
-# labels (config in .github/release-drafter.yml). Nothing is published here — the
+# labels (config in .github/release-drafter.yml). A second pass after a PR is
+# fully merged closes the small event-ordering window where the push can arrive
+# before GitHub exposes that PR as merged. Nothing is published here — the
 # maintainer reviews the draft and clicks "Publish release" when ready, which
 # creates the tag and triggers publish.yml.
 #
@@ -23,13 +25,17 @@ on:
   # token has write access even for fork PRs; the autolabeler only reads the PR
   # title/branch and applies labels — it never checks out or runs the PR's code.
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, closed]
 
 permissions:
   contents: read
 
 jobs:
   update_release_draft:
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.event.action != 'closed' ||
+      github.event.pull_request.merged == true
     permissions:
       contents: write        # create / update the draft release
       pull-requests: write   # autolabeler applies labels to PRs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,6 @@ jobs:
       - name: Compile
         run: npm run compile
       - name: Package smoke VSIX
-        run: npx -y @vscode/vsce@3.9.1 package --out /tmp/claude-code-usage-ci.vsix
+        run: npx -y @vscode/vsce@3.9.2 package --out /tmp/claude-code-usage-ci.vsix
       - name: Verify smoke VSIX
         run: node .github/scripts/verify-vsix.mjs /tmp/claude-code-usage-ci.vsix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
 - **Resilient release delivery** — the verified VSIX is attached to the GitHub
   Release before either registry publish begins, and VS Code Marketplace and
   Open VSX are attempted independently. Both registry uploads use pinned,
-  Node-20-compatible CLIs, bounded retries, and duplicate-safe publishing, so a
-  transient timeout cannot silently block the other registry or leave the
+  Node-engine-compatible CLIs, bounded retries, and duplicate-safe publishing,
+  so a transient timeout cannot silently block the other registry or leave the
   release without its downloadable package. Targeted retries reuse that exact
   attached VSIX; a missing legacy asset is rebuilt once from its release tag.
   A failed asset download is never mistaken for a missing asset or silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
   transient timeout cannot silently block the other registry or leave the
   release without its downloadable package. Targeted retries reuse that exact
   attached VSIX; a missing legacy asset is rebuilt once from its release tag.
+  Release Drafter also performs a merge-complete reconciliation pass so the PR
+  that triggered the main-branch push cannot be omitted by event-ordering races.
 
 ## [2.3.2] — 2026-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this fork compared to upstream
 [`ClaudeCodeUsage/ClaudeCodeUsage`](https://github.com/ClaudeCodeUsage/ClaudeCodeUsage) (last
 upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangelog.com).
 
-## [2.3.2] — Unreleased
+## [2.3.3] — Unreleased
+
+### Fixed
+- **Resilient release delivery** — the verified VSIX is attached to the GitHub
+  Release before either registry publish begins, and VS Code Marketplace and
+  Open VSX are attempted independently. Both registry uploads use pinned,
+  Node-20-compatible CLIs, bounded retries, and duplicate-safe publishing, so a
+  transient timeout cannot silently block the other registry or leave the
+  release without its downloadable package. Targeted retries reuse that exact
+  attached VSIX; a missing legacy asset is rebuilt once from its release tag.
+
+## [2.3.2] — 2026-09-12
 
 ### Added
 - **Project activity matrix (brought forward from the planned v2.3.3)** — the
@@ -58,7 +69,7 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
   endpoints and reset boundaries, and dynamic sharing failures render as text
   instead of interpreted HTML.
 
-## [2.3.1] — Unreleased
+## [2.3.1] — 2026-09-08
 
 ### Added
 - **GPT-6 Astra and Claude Fable 5.1 pricing** — exact model IDs now use their
@@ -275,7 +286,7 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
   explicitly excluded from the VSIX. The human-controlled publish workflow
   stamps package metadata from the reviewed `v2.3.1` release tag.
 
-## [2.3.0] — Unreleased
+## [2.3.0] — 2026-08-28
 
 ### Fixed
 - **Codex Today is now the configured calendar day** — the first Codex tab now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ upstream release: 1.0.8). Format follows [Keep a Changelog](https://keepachangel
   transient timeout cannot silently block the other registry or leave the
   release without its downloadable package. Targeted retries reuse that exact
   attached VSIX; a missing legacy asset is rebuilt once from its release tag.
+  A failed asset download is never mistaken for a missing asset or silently
+  replaced by a rebuild.
   Release Drafter also performs a merge-complete reconciliation pass so the PR
   that triggered the main-branch push cannot be omitted by event-ordering races.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,12 @@ tags:
    then adds your change to a continuously-updated **draft GitHub Release** and
    recomputes the next version.
 3. **To ship, a maintainer reviews that draft and clicks Publish.** That creates
-   the tag and triggers `publish.yml`, which packages and pushes to the VS Code
-   Marketplace + Open VSX and attaches the `.vsix`.
+   the tag and triggers `publish.yml`, which packages and verifies the `.vsix`,
+   attaches it to the GitHub Release, then publishes independently to the VS
+   Code Marketplace and Open VSX. Registry uploads use bounded duplicate-safe
+   retries; a targeted manual retry reuses that attached, verified package and
+   can recover either registry without changing the release tag. Older releases
+   that have no asset yet are rebuilt once from their exact tag and repaired.
 
 Because changes ship by **merging** your PR — not by re-applying it — your commit
 authorship and the PR's *merged* status are preserved.

--- a/src/test/repositoryPolicy.test.ts
+++ b/src/test/repositoryPolicy.test.ts
@@ -1693,7 +1693,7 @@ test('publish pins compatible registry CLIs and isolates all three delivery sink
 
   assert.match(workflow, /node-version:\s*'20'/);
   const packageStep = findRun('npx -y @vscode/vsce@3.9.2 package --out claude-code-usage.vsix');
-  const verifyStep = findRun('node .github/scripts/verify-vsix.mjs claude-code-usage.vsix "${RELEASE_TAG#v}"');
+  const verifyStep = findRun('node .release-policy/.github/scripts/verify-vsix.mjs claude-code-usage.vsix "${RELEASE_TAG#v}"');
   const restoreStep = runs.find(({ value }) => value.includes('gh release download "$RELEASE_TAG"'));
   const publishStep = runs.find(({ value }) => value.includes('@vscode/vsce@3.9.2 publish'));
   const openVsxStep = runs.find(({ value }) => value.includes('ovsx@1.1.1 publish'));
@@ -1701,7 +1701,16 @@ test('publish pins compatible registry CLIs and isolates all three delivery sink
   const attachStep = uses.find(({ value }) =>
     value === 'softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65',
   );
+  const policyCheckout = uses.find(({ line, value }) =>
+    value === 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' &&
+      packageStep !== undefined && line > packageStep.line,
+  );
   assert.ok(packageStep && verifyStep && verifyStep.line > packageStep.line, 'VSIX verification must follow packaging');
+  assert.ok(policyCheckout && verifyStep && policyCheckout.line < verifyStep.line, 'current policy checkout must precede verification');
+  assert.match(workflow, /ref: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(workflow, /path: \.release-policy/);
+  assert.match(workflow, /sparse-checkout: \.github\/scripts/);
+  assert.match(workflow, /persist-credentials: false/);
   assert.ok(restoreStep && verifyStep && verifyStep.line > restoreStep.line, 'manual retries must verify the restored VSIX');
   assert.ok(publishStep && publishStep.line > verifyStep.line, 'VSIX verification must precede Marketplace publish');
   assert.ok(openVsxStep && openVsxStep.line > verifyStep.line, 'VSIX verification must precede Open VSX publish');

--- a/src/test/repositoryPolicy.test.ts
+++ b/src/test/repositoryPolicy.test.ts
@@ -1696,7 +1696,7 @@ test('publish pins compatible registry CLIs and isolates all three delivery sink
   const verifyStep = findRun('node .release-policy/.github/scripts/verify-vsix.mjs claude-code-usage.vsix "${RELEASE_TAG#v}"');
   const restoreStep = runs.find(({ value }) => value.includes('gh release download "$RELEASE_TAG"'));
   const publishStep = runs.find(({ value }) => value.includes('@vscode/vsce@3.9.2 publish'));
-  const openVsxStep = runs.find(({ value }) => value.includes('ovsx@1.1.1 publish'));
+  const openVsxStep = runs.find(({ value }) => value.includes('ovsx@1.2.0 publish'));
   const resultStep = runs.find(({ value }) => value.includes('VSCODE_OUTCOME'));
   const attachStep = uses.find(({ value }) =>
     value === 'softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65',

--- a/src/test/repositoryPolicy.test.ts
+++ b/src/test/repositoryPolicy.test.ts
@@ -82,7 +82,7 @@ function assertExactVscePin(commands: readonly WorkflowStepValue[]): void {
   );
   assert.ok(tokens.length > 0, 'workflow must invoke VSCE');
   for (const token of tokens) {
-    assert.equal(token, '@vscode/vsce@3.9.1', `unexpected VSCE invocation ${token}`);
+    assert.equal(token, '@vscode/vsce@3.9.2', `unexpected VSCE invocation ${token}`);
   }
 }
 
@@ -1549,11 +1549,12 @@ test('changelog records the V2.2.2 energy patch after the released V2.2.1 baseli
   assert.doesNotMatch(changelog, /^## \[2\.2\.[01]\] — Unreleased$/m);
 });
 
-test('changelog records the v2.3.0 through v2.3.2 candidates', () => {
+test('changelog records one v2.3.3 candidate after the released v2.3 line', () => {
   const changelog = repoFile('CHANGELOG.md');
-  assert.match(changelog, /^## \[2\.3\.2\] — Unreleased$/m);
-  assert.match(changelog, /^## \[2\.3\.1\] — Unreleased$/m);
-  assert.match(changelog, /^## \[2\.3\.0\] — Unreleased$/m);
+  assert.match(changelog, /^## \[2\.3\.3\] — Unreleased$/m);
+  assert.match(changelog, /^## \[2\.3\.2\] — 2026-09-12$/m);
+  assert.match(changelog, /^## \[2\.3\.1\] — 2026-09-08$/m);
+  assert.match(changelog, /^## \[2\.3\.0\] — 2026-08-28$/m);
 });
 
 test('release announcements are exact-version and user-disableable', () => {
@@ -1667,7 +1668,7 @@ test('CI has separate Node, browser, and package release gates', () => {
   assert.match(workflow, /PLAYWRIGHT_BROWSERS_PATH:\s*\/ms-playwright/);
   assert.match(workflow, /needs:\s*\[test, ui\]/);
   assert.ok(runValues.includes('npm run test:ui'));
-  const packageAt = runValues.indexOf('npx -y @vscode/vsce@3.9.1 package --out /tmp/claude-code-usage-ci.vsix');
+  const packageAt = runValues.indexOf('npx -y @vscode/vsce@3.9.2 package --out /tmp/claude-code-usage-ci.vsix');
   const verifyAt = runValues.indexOf('node .github/scripts/verify-vsix.mjs /tmp/claude-code-usage-ci.vsix');
   assert.ok(packageAt >= 0 && verifyAt > packageAt, 'smoke VSIX verification must follow packaging');
   assertExactVscePin(runs);
@@ -1683,7 +1684,7 @@ test('CI has separate Node, browser, and package release gates', () => {
   assert.doesNotMatch(workflow, /<pinned-[s]ha>/);
 });
 
-test('publish pins the Node-20-compatible VSCE and verifies before publishing', () => {
+test('publish pins compatible registry CLIs and isolates all three delivery sinks', () => {
   const workflow = repoFile('.github/workflows/publish.yml');
   const runs = workflowStepValues(workflow, 'run');
   const uses = workflowStepValues(workflow, 'uses');
@@ -1691,17 +1692,27 @@ test('publish pins the Node-20-compatible VSCE and verifies before publishing', 
     runs.find((entry) => entry.value === value);
 
   assert.match(workflow, /node-version:\s*'20'/);
-  const packageStep = findRun('npx -y @vscode/vsce@3.9.1 package --out claude-code-usage.vsix');
-  const verifyStep = findRun('node .github/scripts/verify-vsix.mjs claude-code-usage.vsix');
-  const publishStep = findRun('npx -y @vscode/vsce@3.9.1 publish --packagePath claude-code-usage.vsix --pat "$VSCE_PAT"');
-  const openVsxStep = findRun('npx -y ovsx publish claude-code-usage.vsix --pat "$OVSX_PAT"');
+  const packageStep = findRun('npx -y @vscode/vsce@3.9.2 package --out claude-code-usage.vsix');
+  const verifyStep = findRun('node .github/scripts/verify-vsix.mjs claude-code-usage.vsix "${RELEASE_TAG#v}"');
+  const restoreStep = runs.find(({ value }) => value.includes('gh release download "$RELEASE_TAG"'));
+  const publishStep = runs.find(({ value }) => value.includes('@vscode/vsce@3.9.2 publish'));
+  const openVsxStep = runs.find(({ value }) => value.includes('ovsx@1.1.1 publish'));
+  const resultStep = runs.find(({ value }) => value.includes('VSCODE_OUTCOME'));
   const attachStep = uses.find(({ value }) =>
     value === 'softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65',
   );
   assert.ok(packageStep && verifyStep && verifyStep.line > packageStep.line, 'VSIX verification must follow packaging');
+  assert.ok(restoreStep && verifyStep && verifyStep.line > restoreStep.line, 'manual retries must verify the restored VSIX');
   assert.ok(publishStep && publishStep.line > verifyStep.line, 'VSIX verification must precede Marketplace publish');
   assert.ok(openVsxStep && openVsxStep.line > verifyStep.line, 'VSIX verification must precede Open VSX publish');
   assert.ok(attachStep && attachStep.line > verifyStep.line, 'VSIX verification must precede Release attachment');
+  assert.ok(attachStep && publishStep && attachStep.line < publishStep.line, 'Release attachment must not wait for Marketplace');
+  assert.ok(attachStep && openVsxStep && attachStep.line < openVsxStep.line, 'Release attachment must not wait for Open VSX');
+  assert.ok(resultStep && publishStep && openVsxStep && resultStep.line > publishStep.line && resultStep.line > openVsxStep.line);
+  assert.match(publishStep?.value ?? '', /--skip-duplicate/);
+  assert.match(openVsxStep?.value ?? '', /--skip-duplicate/);
+  assert.equal((workflow.match(/steps\.restore_package\.outputs\.restored != 'true'/g) ?? []).length, 4);
+  assert.equal((workflow.match(/continue-on-error: true/g) ?? []).length, 3);
   assertExactVscePin(runs);
   assert.match(workflow, /RELEASE_TAG:[\s\S]*github\.event\.release\.tag_name[\s\S]*inputs\.tag/);
   assert.ok(runs.some(({ value }) => value.includes('npm version "$VER" --no-git-tag-version --allow-same-version')));

--- a/src/test/repositoryPolicy.test.ts
+++ b/src/test/repositoryPolicy.test.ts
@@ -1713,6 +1713,7 @@ test('publish pins compatible registry CLIs and isolates all three delivery sink
   assert.match(openVsxStep?.value ?? '', /--skip-duplicate/);
   assert.equal((workflow.match(/steps\.restore_package\.outputs\.restored != 'true'/g) ?? []).length, 4);
   assert.equal((workflow.match(/continue-on-error: true/g) ?? []).length, 3);
+  assert.equal((workflow.match(/timeout-minutes: 12/g) ?? []).length, 2);
   assertExactVscePin(runs);
   assert.match(workflow, /RELEASE_TAG:[\s\S]*github\.event\.release\.tag_name[\s\S]*inputs\.tag/);
   assert.ok(runs.some(({ value }) => value.includes('npm version "$VER" --no-git-tag-version --allow-same-version')));

--- a/src/test/repositoryPolicy.test.ts
+++ b/src/test/repositoryPolicy.test.ts
@@ -1691,7 +1691,9 @@ test('publish pins compatible registry CLIs and isolates all three delivery sink
   const findRun = (value: string): WorkflowStepValue | undefined =>
     runs.find((entry) => entry.value === value);
 
-  assert.match(workflow, /node-version:\s*'20'/);
+  const releaseNodeMatch = workflow.match(/node-version:\s*'(\d+)'/);
+  assert.ok(releaseNodeMatch, 'publish workflow must pin a Node major');
+  const releaseNodeMajor = Number(releaseNodeMatch[1]);
   const packageStep = findRun('npx -y @vscode/vsce@3.9.2 package --out claude-code-usage.vsix');
   const verifyStep = findRun('node .release-policy/.github/scripts/verify-vsix.mjs claude-code-usage.vsix "${RELEASE_TAG#v}"');
   const restoreStep = runs.find(({ value }) => value.includes('gh release download "$RELEASE_TAG"'));
@@ -1720,6 +1722,16 @@ test('publish pins compatible registry CLIs and isolates all three delivery sink
   assert.ok(resultStep && publishStep && openVsxStep && resultStep.line > publishStep.line && resultStep.line > openVsxStep.line);
   assert.match(publishStep?.value ?? '', /--skip-duplicate/);
   assert.match(openVsxStep?.value ?? '', /--skip-duplicate/);
+  const openVsxVersion = openVsxStep?.value.match(/\bovsx@(\d+\.\d+\.\d+)\b/)?.[1];
+  const openVsxMinimumNodeMajor: Readonly<Record<string, number>> = {
+    // npm package metadata: ovsx@1.2.0 engines.node is >=22.0.0.
+    '1.2.0': 22,
+  };
+  assert.ok(openVsxVersion, 'Open VSX CLI must be exactly version-pinned');
+  assert.ok(
+    releaseNodeMajor >= (openVsxMinimumNodeMajor[openVsxVersion] ?? Number.POSITIVE_INFINITY),
+    `Node ${releaseNodeMajor} does not satisfy ovsx@${openVsxVersion}`,
+  );
   assert.equal((workflow.match(/steps\.restore_package\.outputs\.restored != 'true'/g) ?? []).length, 4);
   assert.equal((workflow.match(/continue-on-error: true/g) ?? []).length, 3);
   assert.equal((workflow.match(/timeout-minutes: 12/g) ?? []).length, 2);


### PR DESCRIPTION
## Summary

- attach the verified VSIX to the GitHub Release before either registry upload
- publish VS Code Marketplace and Open VSX independently with bounded, duplicate-safe retries
- let manual retries reuse the exact attached package, or rebuild a missing legacy asset from its release tag
- run the pinned publishing tools on a supported Node 22 runtime
- reconcile Release Drafter after a pull request is fully merged

## Why

The initial v2.3.1 and v2.3.2 release jobs both reached the VS Code Marketplace upload and timed out after about 180 seconds at /_apis/gallery. The former fail-fast sequence then skipped Open VSX and the GitHub Release asset. A targeted retry later published v2.3.1 successfully, confirming that the package, version, and credentials were valid and that the workflow needed transient-failure recovery.

## Verification

- complete Node test suite passes under Node 22
- release-policy tests cover independent delivery, bounded retries, exact-tag recovery, package-policy verification, and current CLI engine requirements
- the v2.3.2 recovery VSIX passes the current package verifier

Publishing remains maintainer controlled. This pull request changes delivery reliability only and does not publish a release by itself.
